### PR TITLE
Fix project deprecation warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env rake
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project'
+require 'motion/project/template/ios'
 require "bundler/gem_tasks"
 Bundler.setup
 Bundler.require


### PR DESCRIPTION
This changed in RubyMotion 2.
