### PR TITLE
belongs_to accept :class_name as well

### DIFF
--- a/lib/motion-resource/associations.rb
+++ b/lib/motion-resource/associations.rb
@@ -67,7 +67,12 @@ module MotionResource
         end
       end
 
-      def belongs_to(name, params = lambda { |o| Hash.new })
+      def belongs_to(name, options = {} )
+        default_options = {
+          :params => lambda { |o| Hash.new },
+          :class_name => name.to_s.classify
+        }
+        options = default_options.merge(options)
         define_method name do |&block|
           if block.nil?
             instance_variable_get("@#{name}")
@@ -78,7 +83,7 @@ module MotionResource
               return
             end
             
-            Object.const_get(name.to_s.classify).find(self.send("#{name}_id"), params.call(self)) do |result, response|
+            Object.const_get(options[:class_name]).find(self.send("#{name}_id"), options[:params].call(self)) do |result, response|
               instance_variable_set("@#{name}", result)
               instance_variable_set("@#{name}_response", response)
               MotionResource::Base.request_block_call(block, result, response)

--- a/lib/motion-resource/associations.rb
+++ b/lib/motion-resource/associations.rb
@@ -73,7 +73,6 @@ module MotionResource
           :class_name => name.to_s.classify
         }
         options = default_options.merge(options)
-        klass = Object.const_get(options[:class_name])
 
         define_method name do |&block|
           if block.nil?
@@ -85,6 +84,7 @@ module MotionResource
               return
             end
             
+            klass = Object.const_get(options[:class_name])
             klass.find(self.send("#{name}_id"), options[:params].call(self)) do |result, response|
               instance_variable_set("@#{name}", result)
               instance_variable_set("@#{name}_response", response)
@@ -94,7 +94,7 @@ module MotionResource
         end
         
         define_method "#{name}=" do |value|
-          value = klass.instantiate(value) if value.is_a?(Hash)
+          value = Object.const_get(options[:class_name]).instantiate(value) if value.is_a?(Hash)
           instance_variable_set("@#{name}", value)
         end
         

--- a/lib/motion-resource/associations.rb
+++ b/lib/motion-resource/associations.rb
@@ -73,6 +73,8 @@ module MotionResource
           :class_name => name.to_s.classify
         }
         options = default_options.merge(options)
+        klass = Object.const_get(options[:class_name])
+
         define_method name do |&block|
           if block.nil?
             instance_variable_get("@#{name}")
@@ -83,7 +85,7 @@ module MotionResource
               return
             end
             
-            Object.const_get(options[:class_name]).find(self.send("#{name}_id"), options[:params].call(self)) do |result, response|
+            klass.find(self.send("#{name}_id"), options[:params].call(self)) do |result, response|
               instance_variable_set("@#{name}", result)
               instance_variable_set("@#{name}_response", response)
               MotionResource::Base.request_block_call(block, result, response)
@@ -92,7 +94,6 @@ module MotionResource
         end
         
         define_method "#{name}=" do |value|
-          klass = Object.const_get(name.to_s.classify)
           value = klass.instantiate(value) if value.is_a?(Hash)
           instance_variable_set("@#{name}", value)
         end

--- a/lib/motion-resource/associations.rb
+++ b/lib/motion-resource/associations.rb
@@ -67,13 +67,12 @@ module MotionResource
         end
       end
 
-      def belongs_to(name, options = {} )
+      def belongs_to(name, options = {})
         default_options = {
           :params => lambda { |o| Hash.new },
           :class_name => name.to_s.classify
         }
         options = default_options.merge(options)
-
         define_method name do |&block|
           if block.nil?
             instance_variable_get("@#{name}")
@@ -83,7 +82,6 @@ module MotionResource
               MotionResource::Base.request_block_call(block, cached, cached_response)
               return
             end
-            
             klass = Object.const_get(options[:class_name])
             klass.find(self.send("#{name}_id"), options[:params].call(self)) do |result, response|
               instance_variable_set("@#{name}", result)

--- a/spec/env.rb
+++ b/spec/env.rb
@@ -1,5 +1,4 @@
 MotionResource::Base.root_url = 'http://example.com/'
-
 class Post < MotionResource::Base
   attr_accessor :text
   
@@ -10,13 +9,14 @@ class Post < MotionResource::Base
 end
 
 class Comment < MotionResource::Base
-  attr_accessor :post_id, :text
+  attr_accessor :post_id, :account_id, :text
   
   self.member_url = 'comments/:id'
   self.collection_url = 'comments'
   
   belongs_to :post
-  
+  belongs_to :account, :class_name=>'User'
+
   scope :recent, :url => 'comments/recent'
   
   custom_urls :by_user_url => 'comments/by_user/:name'

--- a/spec/env.rb
+++ b/spec/env.rb
@@ -1,4 +1,5 @@
 MotionResource::Base.root_url = 'http://example.com/'
+
 class Post < MotionResource::Base
   attr_accessor :text
   
@@ -10,7 +11,6 @@ end
 
 class User < MotionResource::Base
   self.member_url = 'users/:id'
-  
   has_one :profile
 end
 
@@ -22,9 +22,7 @@ class Comment < MotionResource::Base
   
   belongs_to :post
   belongs_to :account, :class_name=>'User'
-
   scope :recent, :url => 'comments/recent'
-  
   custom_urls :by_user_url => 'comments/by_user/:name'
 end
 

--- a/spec/env.rb
+++ b/spec/env.rb
@@ -8,6 +8,12 @@ class Post < MotionResource::Base
   has_many :parent_posts, :class_name => 'Post'
 end
 
+class User < MotionResource::Base
+  self.member_url = 'users/:id'
+  
+  has_one :profile
+end
+
 class Comment < MotionResource::Base
   attr_accessor :post_id, :account_id, :text
   
@@ -20,12 +26,6 @@ class Comment < MotionResource::Base
   scope :recent, :url => 'comments/recent'
   
   custom_urls :by_user_url => 'comments/by_user/:name'
-end
-
-class User < MotionResource::Base
-  self.member_url = 'users/:id'
-  
-  has_one :profile
 end
 
 class Profile < MotionResource::Base

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -91,6 +91,21 @@ describe "belongs_to" do
         @response.should.be.ok
       end
     end
+
+    it "should return correct type of object" do
+      stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, text: 'Hello' })
+      @comment = Comment.new(:account_id => 1)
+      @comment.account do |results, response|
+        @account = results
+        @response = response
+        resume
+      end
+      wait_max 1.0 do
+        @response.should.be.ok
+        @account.class.should == User
+      end
+    end
+
   end
   
   describe "writer" do

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -114,11 +114,18 @@ describe "belongs_to" do
       comment.post = { :id => 1, :text => 'Hello' }
       comment.post.should.is_a Post
     end
+
+    it "should convert hash to proper type" do
+      comment = Comment.new
+      comment.account = { :id => 1, :text => 'Hello' }
+      comment.account.class.should == User
+    end
     
     it "should set attributes when assigned with hash" do
       comment = Comment.new
       comment.post = { :id => 1, :text => 'Hello' }
       comment.post.text.should == 'Hello'
+      comment.post.class.should == Post
     end
     
     it "should use identity map when assigned with hash" do


### PR DESCRIPTION
Extend belongs_to to use same syntax as has_many.  

In my codebase, I've got several objects that belong_to a common Address class, but refer to it as billing_address, shipping_address, etc.

As you've probably observed, this will be a breaking change for everyone who's using the params option to belongs_to.  I'm unsure how popular that option is.

To smooth this, I could put a type check on options to see if it's a Proc, and if so, populate the options[:params] with it.  Something like:

``` ruby
    def belongs_to(name, options={} )
        if options.is_a?(Proc) 
          options = {
            :params => options
            :class_name => name.to_s.classify
          }
       else
         // code as it is in patch
```

You could leave that check in for a few releases then take it out eventually 
