### PR TITLE
Use AFMotion instead of Bubblewrap for HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ resources/*.storyboardc
 Gemfile.lock
 pkg/*
 .dat*
+vendor/Pods
+examples/Colr/vendor/Pods

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "bubble-wrap", "~> 1.6.0"
-gem "afmotion", "~> 2.1.0"
+gem "afmotion", ">= 2.3.0"
 gem "motion-support", ">= 0.2.4"
 gem "webstub", "~> 1.0.1"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
-gem "bubble-wrap", "1.3.0.osx"
+gem "bubble-wrap", "~> 1.6.0"
+gem "afmotion", "~> 2.1.0"
 gem "motion-support", ">= 0.2.4"
 gem "webstub", :git => 'git://github.com/mattgreen/webstub.git'
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 gem "bubble-wrap", "~> 1.6.0"
 gem "afmotion", "~> 2.1.0"
 gem "motion-support", ">= 0.2.4"
-gem "webstub", :git => 'git://github.com/mattgreen/webstub.git'
+gem "webstub", "~> 1.0.1"
 
 # Specify your gem's dependencies in motion-support.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Add MotionResource to your Gemfile, like this:
 
     gem "motion-resource"
 
+Then install AFNetworking:
+
+    rake pod:install
+
 ## Example
 
 Consider this example for a fictional blog API.
@@ -71,7 +75,7 @@ Pass a second block parameter to capture error information:
 
 ```ruby
 User.find_all do |users, response|
-  if response.ok?
+  if response.success?
     puts users.inspect
   else
     App.alert response.error_message
@@ -79,7 +83,7 @@ User.find_all do |users, response|
 end
 ```
 
-`response` will be an instance of [BubbleWrap::HTTP::Response](http://rdoc.info/github/rubymotion/BubbleWrap/master/file/README.md#HTTP)
+`response` will be an instance of [AFMotion::HTTP::Response](https://github.com/usepropeller/afmotion/blob/master/README.md)
 
 ## Reachability
 

--- a/examples/Colr/Rakefile
+++ b/examples/Colr/Rakefile
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project'
+require 'motion/project/template/ios'
 
 require '../../lib/motion-resource'
 

--- a/examples/Colr/vendor/Podfile.lock
+++ b/examples/Colr/vendor/Podfile.lock
@@ -1,0 +1,27 @@
+PODS:
+  - AFNetworking (2.1.0):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+    - AFNetworking/UIKit
+  - AFNetworking/NSURLConnection (2.1.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.1.0):
+    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (2.1.0)
+  - AFNetworking/Security (2.1.0)
+  - AFNetworking/Serialization (2.1.0)
+  - AFNetworking/UIKit (2.1.0):
+    - AFNetworking/NSURLConnection
+
+DEPENDENCIES:
+  - AFNetworking (~> 2.1.0)
+
+SPEC CHECKSUMS:
+  AFNetworking: c7d7901a83f631414c7eda1737261f696101a5cd
+
+COCOAPODS: 0.32.1

--- a/lib/motion-resource.rb
+++ b/lib/motion-resource.rb
@@ -1,4 +1,5 @@
 require 'motion-support'
 require 'bubble-wrap'
+require 'afmotion'
 
 Motion::Require.all(Dir.glob(File.expand_path('../motion-resource/**/*.rb', __FILE__)))

--- a/lib/motion-resource/base.rb
+++ b/lib/motion-resource/base.rb
@@ -47,7 +47,7 @@ module MotionResource
       end
       
       def json_root
-        self.name.underscore.pluralize
+        self.name.underscore
       end
 
       def identity_map

--- a/lib/motion-resource/find.rb
+++ b/lib/motion-resource/find.rb
@@ -28,7 +28,7 @@ module MotionResource
             if json.class == Array
               arr_rep = json
             elsif json.class == Hash
-              root = self.json_root
+              root = self.json_root.pluralize
               if json.has_key?(root) || json.has_key?(root.to_sym)
                 arr_rep = json[root] || json[root.to_sym]
               end

--- a/lib/motion-resource/find.rb
+++ b/lib/motion-resource/find.rb
@@ -11,7 +11,7 @@ module MotionResource
       
       def fetch_member(url, &block)
         get(url) do |response, json|
-          if response.ok?
+          if response.success?
             obj = instantiate(json)
             request_block_call(block, obj, response)
           else
@@ -22,7 +22,7 @@ module MotionResource
 
       def fetch_collection(url, &block)
         get(url) do |response, json|
-          if response.ok?
+          if response.success?
             objs = []
             arr_rep = nil
             if json.class == Array

--- a/lib/motion-resource/logger.rb
+++ b/lib/motion-resource/logger.rb
@@ -1,6 +1,6 @@
 module MotionResource
   class Base
     class_attribute :logger
-    self.logger = MotionSupport::NullLogger.new
+    self.logger = MotionSupport::StdoutLogger.new
   end
 end

--- a/lib/motion-resource/requests.rb
+++ b/lib/motion-resource/requests.rb
@@ -45,8 +45,11 @@ module MotionResource
             return BubbleWrap::JSON.parse(body)
           end
         else
-          if result.operation.response.statusCode.to_s =~ /401/ && @on_auth_failure
-            @on_auth_failure.call
+          logger.log "failed result: #{result.inspect}"
+          if result.operation.response
+            if result.operation.response.statusCode.to_s =~ /401/ && @on_auth_failure
+              @on_auth_failure.call
+            end
           end
           return nil
         end

--- a/lib/motion-resource/requests.rb
+++ b/lib/motion-resource/requests.rb
@@ -35,17 +35,17 @@ module MotionResource
 
       protected
 
-      def decode_response(response, url, options)
-        if response.success?
-          body = response.object
-          logger.log "response: #{body}"
+      def decode_response(result, url, options)
+        if result.success?
+          body = result.object
+          logger.log "result: #{body}"
           if body.blank?
             return {}
           else
             return BubbleWrap::JSON.parse(body)
           end
         else
-          if response.operation.response.statusCode.to_s =~ /401/ && @on_auth_failure
+          if result.operation.response.statusCode.to_s =~ /401/ && @on_auth_failure
             @on_auth_failure.call
           end
           return nil

--- a/lib/motion-resource/requests.rb
+++ b/lib/motion-resource/requests.rb
@@ -36,8 +36,8 @@ module MotionResource
       protected
 
       def decode_response(response, url, options)
-        if response.ok?
-          body = response.body.to_str.strip rescue nil
+        if response.success?
+          body = response.object
           logger.log "response: #{body}"
           if body.blank?
             return {}
@@ -45,7 +45,7 @@ module MotionResource
             return BubbleWrap::JSON.parse(body)
           end
         else
-          if response.status_code.to_s =~ /401/ && @on_auth_failure
+          if response.operation.response.statusCode.to_s =~ /401/ && @on_auth_failure
             @on_auth_failure.call
           end
           return nil
@@ -78,7 +78,7 @@ module MotionResource
         logger.log "#{method.upcase} #{url}"
         logger.log "payload: #{options[:payload]}" if options[:payload]
 
-        BubbleWrap::HTTP.send(method, url, options) do |response|
+        AFMotion::HTTP.send(method, url, (options[:payload] ? options[:payload] : options)) do |response|
           block.call response, decode_response(response, url, options)
         end
       end

--- a/lib/motion-resource/version.rb
+++ b/lib/motion-resource/version.rb
@@ -1,3 +1,3 @@
 module MotionResource
-  VERSION = "0.2.0"
+  VERSION = "0.1.4"
 end

--- a/lib/motion-resource/version.rb
+++ b/lib/motion-resource/version.rb
@@ -1,3 +1,3 @@
 module MotionResource
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/lib/motion-resource/version.rb
+++ b/lib/motion-resource/version.rb
@@ -1,3 +1,3 @@
 module MotionResource
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/motion-resource.gemspec
+++ b/motion-resource.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'bubble-wrap'
+  s.add_dependency 'afmotion', "~> 2.1.0"
   s.add_dependency 'motion-support', '>= 0.2.3'
   s.add_development_dependency 'rake'
 end

--- a/motion-resource.gemspec
+++ b/motion-resource.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'bubble-wrap'
-  s.add_dependency 'afmotion', "~> 2.1.0"
-  s.add_dependency 'motion-support', '>= 0.2.3'
+  s.add_dependency 'afmotion', ">= 2.1.0"
+  s.add_dependency 'motion-support', '>= 0.2.6'
   s.add_development_dependency 'rake'
 end

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -1,5 +1,10 @@
 describe "belongs_to" do
   extend WebStub::SpecHelpers
+
+  before do
+    disable_network_access!
+    stub_request(:post, "http://example.com/comments.json").to_return(json: { id: 1 })
+  end
   
   it "should define reader" do
     Comment.new.should.respond_to :post
@@ -24,6 +29,7 @@ describe "belongs_to" do
     extend WebStub::SpecHelpers
     
     before do
+      disable_network_access!
       stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, text: 'Hello' })
     end
     

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -88,7 +88,7 @@ describe "belongs_to" do
       end
       
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
 
@@ -101,7 +101,7 @@ describe "belongs_to" do
         resume
       end
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
         @account.class.should == User
       end
     end

--- a/spec/motion-resource/associations/has_many_spec.rb
+++ b/spec/motion-resource/associations/has_many_spec.rb
@@ -122,7 +122,7 @@ describe "has_many" do
       end
       
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
   end

--- a/spec/motion-resource/associations/has_many_spec.rb
+++ b/spec/motion-resource/associations/has_many_spec.rb
@@ -1,5 +1,9 @@
 describe "has_many" do
   extend WebStub::SpecHelpers
+
+  before do
+    disable_network_access!
+  end
   
   it "should define reader" do
     Post.new.should.respond_to :comments
@@ -24,6 +28,7 @@ describe "has_many" do
     extend WebStub::SpecHelpers
   
     before do
+      disable_network_access!
       stub_request(:get, "http://example.com/posts.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
     end
   
@@ -45,6 +50,7 @@ describe "has_many" do
     extend WebStub::SpecHelpers
     
     before do
+      disable_network_access!
       stub_request(:get, "http://example.com/comments.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
     end
     

--- a/spec/motion-resource/associations/has_one_spec.rb
+++ b/spec/motion-resource/associations/has_one_spec.rb
@@ -1,5 +1,9 @@
 describe "has_one" do
   extend WebStub::SpecHelpers
+
+  before do
+    disable_network_access!
+  end
   
   it "should define reader" do
     User.new.should.respond_to :profile

--- a/spec/motion-resource/associations/scope_spec.rb
+++ b/spec/motion-resource/associations/scope_spec.rb
@@ -2,6 +2,7 @@ describe "scope" do
   extend WebStub::SpecHelpers
   
   before do
+    disable_network_access!
     stub_request(:get, "http://example.com/comments/recent.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
   end
   

--- a/spec/motion-resource/associations/scope_spec.rb
+++ b/spec/motion-resource/associations/scope_spec.rb
@@ -28,7 +28,7 @@ describe "scope" do
     end
       
     wait_max 1.0 do
-      @response.should.be.ok
+      @response.should.be.success
     end
   end
 end

--- a/spec/motion-resource/callbacks_spec.rb
+++ b/spec/motion-resource/callbacks_spec.rb
@@ -22,6 +22,10 @@ describe "base" do
   extend WebStub::SpecHelpers
   extend MotionResource::SpecHelpers
 
+  before do
+    disable_network_access!
+  end
+
   describe "callbacks" do
     it "should run create callbacks" do
       stub_request(:post, "http://example.com/models.json").to_return(json: {})

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -1,5 +1,9 @@
 describe "crud" do
   extend WebStub::SpecHelpers
+
+  before do
+    disable_network_access!
+  end
   
   describe "create" do
     it "should create on save if record is new" do

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -62,7 +62,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
     
@@ -74,7 +74,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
     
@@ -86,7 +86,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
     
@@ -157,7 +157,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
     
@@ -170,7 +170,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
   end
@@ -210,7 +210,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
   end
@@ -250,7 +250,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
   end

--- a/spec/motion-resource/find_spec.rb
+++ b/spec/motion-resource/find_spec.rb
@@ -1,5 +1,9 @@
 describe "find" do
   extend WebStub::SpecHelpers
+
+  before do
+    disable_network_access!
+  end
   
   it "should find single record" do
     stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })

--- a/spec/motion-resource/requests_spec.rb
+++ b/spec/motion-resource/requests_spec.rb
@@ -1,6 +1,10 @@
 describe "requests" do
   extend WebStub::SpecHelpers
 
+  before do
+    disable_network_access!
+  end
+
   it "should define GET method on instance and class" do
     Comment.new.should.respond_to :get
     Comment.should.respond_to :get

--- a/vendor/Podfile.lock
+++ b/vendor/Podfile.lock
@@ -1,0 +1,27 @@
+PODS:
+  - AFNetworking (2.1.0):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+    - AFNetworking/UIKit
+  - AFNetworking/NSURLConnection (2.1.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.1.0):
+    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (2.1.0)
+  - AFNetworking/Security (2.1.0)
+  - AFNetworking/Serialization (2.1.0)
+  - AFNetworking/UIKit (2.1.0):
+    - AFNetworking/NSURLConnection
+
+DEPENDENCIES:
+  - AFNetworking (~> 2.1.0)
+
+SPEC CHECKSUMS:
+  AFNetworking: c7d7901a83f631414c7eda1737261f696101a5cd
+
+COCOAPODS: 0.32.1


### PR DESCRIPTION
This request is because Bubblewrap is removing their HTTP module:
https://github.com/rubymotion/BubbleWrap/issues/308

I tried to change as little as possible, but "success" is returned by AFMotion instead of "ok" like Bubblewrap. So this is a breaking change. I could create a pull request on AFMotion to add an alias but "success" is actually more correct.

The specs are broken because Webstub does not support AFMotion. It's noted here:
https://github.com/mattgreen/webstub/issues/20
I tested with my app and the example app and I haven't found any issues. Not sure what to do about it.

It would be better to move to AFMotion's JSON parser and remove Bubblewrap entirely but that is a bigger change that I didn't want to tackle.
