### PR TITLE
Use AFMotion instead of BubbleWrap for HTTP (redux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ resources/*.storyboardc
 Gemfile.lock
 pkg/*
 .dat*
+vendor/Pods
+examples/Colr/vendor/Pods

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
 source "http://rubygems.org"
 
 gem "bubble-wrap", "~> 1.6.0"
-gem "afmotion", "~> 2.1.0"
-gem "motion-support", ">= 0.2.4"
 gem "webstub", :git => 'git://github.com/mattgreen/webstub.git'
+gem "motion-redgreen"
 
-# Specify your gem's dependencies in motion-support.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
 gem "webstub", :git => 'git://github.com/mattgreen/webstub.git'
-gem "afmotion", :git => '/Users/mark/projects/open-source/afmotion'
+gem "afmotion", :git => 'https://github.com/usepropeller/afmotion.git'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
-gem "bubble-wrap", "1.3.0.osx"
+gem "bubble-wrap", "~> 1.6.0"
+gem "afmotion", "~> 2.1.0"
 gem "motion-support", ">= 0.2.4"
 gem "webstub", :git => 'git://github.com/mattgreen/webstub.git'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "http://rubygems.org"
 
-gem "bubble-wrap", "~> 1.6.0"
 gem "webstub", :git => 'git://github.com/mattgreen/webstub.git'
-gem "motion-redgreen"
+gem "afmotion", :git => '/Users/mark/projects/open-source/afmotion'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Pass a second block parameter to capture error information:
 
 ```ruby
 User.find_all do |users, response|
-  if response.success?
+  if response.success? # response.ok? also works
     puts users.inspect
   else
     App.alert response.error_message

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Add MotionResource to your Gemfile, like this:
 
     gem "motion-resource"
 
+Then install AFNetworking:
+
+    rake pod:install
+
 ## Example
 
 Consider this example for a fictional blog API.
@@ -71,7 +75,7 @@ Pass a second block parameter to capture error information:
 
 ```ruby
 User.find_all do |users, response|
-  if response.ok?
+  if response.success?
     puts users.inspect
   else
     App.alert response.error_message
@@ -79,7 +83,7 @@ User.find_all do |users, response|
 end
 ```
 
-`response` will be an instance of [BubbleWrap::HTTP::Response](http://rdoc.info/github/rubymotion/BubbleWrap/master/file/README.md#HTTP)
+`response` will be an instance of [AFMotion::HTTP::Response](https://github.com/usepropeller/afmotion/blob/master/README.md)
 
 ## Reachability
 

--- a/examples/Colr/Rakefile
+++ b/examples/Colr/Rakefile
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project'
+require 'motion/project/template/ios'
 
 require '../../lib/motion-resource'
 

--- a/examples/Colr/vendor/Podfile.lock
+++ b/examples/Colr/vendor/Podfile.lock
@@ -1,0 +1,27 @@
+PODS:
+  - AFNetworking (2.1.0):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+    - AFNetworking/UIKit
+  - AFNetworking/NSURLConnection (2.1.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.1.0):
+    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (2.1.0)
+  - AFNetworking/Security (2.1.0)
+  - AFNetworking/Serialization (2.1.0)
+  - AFNetworking/UIKit (2.1.0):
+    - AFNetworking/NSURLConnection
+
+DEPENDENCIES:
+  - AFNetworking (~> 2.1.0)
+
+SPEC CHECKSUMS:
+  AFNetworking: c7d7901a83f631414c7eda1737261f696101a5cd
+
+COCOAPODS: 0.32.1

--- a/lib/motion-resource.rb
+++ b/lib/motion-resource.rb
@@ -1,4 +1,5 @@
 require 'motion-support'
 require 'bubble-wrap'
+require 'afmotion'
 
 Motion::Require.all(Dir.glob(File.expand_path('../motion-resource/**/*.rb', __FILE__)))

--- a/lib/motion-resource.rb
+++ b/lib/motion-resource.rb
@@ -1,5 +1,4 @@
 require 'motion-support'
-require 'bubble-wrap'
 require 'afmotion'
 
 Motion::Require.all(Dir.glob(File.expand_path('../motion-resource/**/*.rb', __FILE__)))

--- a/lib/motion-resource/base.rb
+++ b/lib/motion-resource/base.rb
@@ -47,7 +47,7 @@ module MotionResource
       end
       
       def json_root
-        self.name.underscore.pluralize
+        self.name.underscore
       end
 
       def identity_map

--- a/lib/motion-resource/callbacks.rb
+++ b/lib/motion-resource/callbacks.rb
@@ -1,7 +1,7 @@
 module MotionResource
   class Base
     include MotionSupport::Callbacks
-    
+
     define_callbacks :create, :save, :update, :destroy
 
     [:create, :save, :update, :destroy].each do |callback|

--- a/lib/motion-resource/find.rb
+++ b/lib/motion-resource/find.rb
@@ -28,7 +28,7 @@ module MotionResource
             if json.class == Array
               arr_rep = json
             elsif json.class == Hash
-              root = self.json_root
+              root = self.json_root.pluralize
               if json.has_key?(root) || json.has_key?(root.to_sym)
                 arr_rep = json[root] || json[root.to_sym]
               end

--- a/lib/motion-resource/find.rb
+++ b/lib/motion-resource/find.rb
@@ -8,7 +8,7 @@ module MotionResource
       def find_all(params = {}, &block)
         fetch_collection(self.url_encoder.fill_url_params(collection_url_or_default, params), &block)
       end
-      
+
       def fetch_member(url, &block)
         get(url) do |response, json|
           if response.success?
@@ -49,7 +49,7 @@ module MotionResource
           end
         end
       end
-      
+
       def request_block_call(block, default_arg, extra_arg)
         if block
           if block.arity == 1

--- a/lib/motion-resource/find.rb
+++ b/lib/motion-resource/find.rb
@@ -11,7 +11,7 @@ module MotionResource
       
       def fetch_member(url, &block)
         get(url) do |response, json|
-          if response.ok?
+          if response.success?
             obj = instantiate(json)
             request_block_call(block, obj, response)
           else
@@ -22,7 +22,7 @@ module MotionResource
 
       def fetch_collection(url, &block)
         get(url) do |response, json|
-          if response.ok?
+          if response.success?
             objs = []
             arr_rep = nil
             if json.class == Array

--- a/lib/motion-resource/requests.rb
+++ b/lib/motion-resource/requests.rb
@@ -90,6 +90,7 @@ module MotionResource
         logger.log "payload: #{options[:payload]}" if options[:payload]
 
         params = (options[:payload] ? options[:payload] : options)
+        params = nil if params.empty?
         case method
         when :get
           AFMotion::JSON.get(url) do |response|

--- a/lib/motion-resource/requests.rb
+++ b/lib/motion-resource/requests.rb
@@ -74,6 +74,7 @@ module MotionResource
         params = nil if params.empty?
         AFMotion::JSON.send(method, url, params) do |response|
           def response.ok?
+            NSLog "[DEPRECATED] `ok?` is deprecated.  Please use `success?` instead."
             success?
           end
           block.call response, decode_response(response)

--- a/lib/motion-resource/requests.rb
+++ b/lib/motion-resource/requests.rb
@@ -73,6 +73,9 @@ module MotionResource
         params = (options[:payload] ? options[:payload] : options)
         params = nil if params.empty?
         AFMotion::JSON.send(method, url, params) do |response|
+          def response.ok?
+            success?
+          end
           block.call response, decode_response(response)
         end
       end

--- a/lib/motion-resource/requests.rb
+++ b/lib/motion-resource/requests.rb
@@ -36,8 +36,8 @@ module MotionResource
       protected
 
       def decode_response(response, url, options)
-        if response.ok?
-          body = response.body.to_str.strip rescue nil
+        if response.success?
+          body = response.object
           logger.log "response: #{body}"
           if body.blank?
             return {}
@@ -45,7 +45,7 @@ module MotionResource
             return BubbleWrap::JSON.parse(body)
           end
         else
-          if response.status_code.to_s =~ /401/ && @on_auth_failure
+          if response.operation.response.statusCode.to_s =~ /401/ && @on_auth_failure
             @on_auth_failure.call
           end
           return nil
@@ -78,7 +78,7 @@ module MotionResource
         logger.log "#{method.upcase} #{url}"
         logger.log "payload: #{options[:payload]}" if options[:payload]
 
-        BubbleWrap::HTTP.send(method, url, options) do |response|
+        AFMotion::HTTP.send(method, url, (options[:payload] ? options[:payload] : options)) do |response|
           block.call response, decode_response(response, url, options)
         end
       end

--- a/lib/motion-resource/version.rb
+++ b/lib/motion-resource/version.rb
@@ -1,3 +1,3 @@
 module MotionResource
-  VERSION = "0.2.0"
+  VERSION = "0.1.4"
 end

--- a/lib/motion-resource/version.rb
+++ b/lib/motion-resource/version.rb
@@ -1,3 +1,3 @@
 module MotionResource
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/motion-resource.gemspec
+++ b/motion-resource.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'bubble-wrap'
+  s.add_dependency 'afmotion', "~> 2.1.0"
   s.add_dependency 'motion-support', '>= 0.2.3'
   s.add_development_dependency 'rake'
 end

--- a/motion-resource.gemspec
+++ b/motion-resource.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'bubble-wrap'
-  s.add_dependency 'afmotion', "~> 2.1.0"
-  s.add_dependency 'motion-support', '>= 0.2.3'
+  s.add_dependency 'afmotion', "~> 2.3.1"
+  s.add_dependency 'motion-support', '>= 0.2.6'
   s.add_development_dependency 'rake'
 end

--- a/motion-resource.gemspec
+++ b/motion-resource.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency 'bubble-wrap'
   s.add_dependency 'afmotion', "~> 2.3.1"
   s.add_dependency 'motion-support', '>= 0.2.6'
   s.add_development_dependency 'rake'

--- a/motion-resource.gemspec
+++ b/motion-resource.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'afmotion', "~> 2.3.1"
-  s.add_dependency 'motion-support', '>= 0.2.6'
+  s.add_dependency 'motion-support', '>= 0.2.3'
   s.add_development_dependency 'rake'
 end

--- a/spec/env.rb
+++ b/spec/env.rb
@@ -2,19 +2,19 @@ MotionResource::Base.root_url = 'http://example.com/'
 
 class Post < MotionResource::Base
   attr_accessor :text
-  
+
   self.member_url = 'posts/:id'
-  
+
   has_many :comments
   has_many :parent_posts, :class_name => 'Post'
 end
 
 class Comment < MotionResource::Base
   attr_accessor :post_id, :account_id, :text
-  
+
   self.member_url = 'comments/:id'
   self.collection_url = 'comments'
-  
+
   belongs_to :post
   belongs_to :account, :class_name => 'User'
   scope :recent, :url => 'comments/recent'
@@ -29,7 +29,7 @@ end
 
 class User < MotionResource::Base
   self.member_url = 'users/:id'
-  
+
   has_one :profile
 end
 

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -91,18 +91,6 @@ describe "belongs_to" do
       end
     end
 
-    it "should give HTTP response to block" do
-      @comment = Comment.new(:post_id => 1)
-      @comment.post do |results, response|
-        @response = response
-        resume
-      end
-
-      wait_max 1.0 do
-        @response.should.be.success
-      end
-    end
-
     it "should return correct type of object" do
       stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, text: 'Hello' })
       @comment = Comment.new(:account_id => 1)

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -1,55 +1,55 @@
 describe "belongs_to" do
   extend WebStub::SpecHelpers
-  
+
   it "should define reader" do
     Comment.new.should.respond_to :post
   end
-  
+
   it "should define writer" do
     Comment.new.should.respond_to :post=
   end
-  
+
   it "should define reset method" do
     Comment.new.should.respond_to :reset_post
   end
-  
+
   it "should reset" do
     comment = Comment.new
     comment.post = Post.new
     comment.reset_post
     comment.post.should.be.nil
   end
-  
+
   describe "reader" do
     extend WebStub::SpecHelpers
-    
+
     before do
       stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, text: 'Hello' })
     end
-    
+
     it "should by default return nil when called without a block" do
       Comment.new.post.should.be.nil
     end
-    
+
     it "should return any cached values when called without a block" do
       comment = Comment.new
       post = Post.new
       comment.post = post
       comment.post.should == post
     end
-    
+
     it "should fetch resource when called with a block" do
       @comment = Comment.new(:post_id => 1)
       @comment.post do |result|
         @result = result
         resume
       end
-      
+
       wait_max 1.0 do
         @result.text.should == 'Hello'
       end
     end
-    
+
     it "should return cached resource immediately if exist when called with a block" do
       post = Post.new
       @comment = Comment.new
@@ -58,7 +58,7 @@ describe "belongs_to" do
         result.should == post
       end
     end
-    
+
     it "should give cached HTTP response immediately if exist when called with a block" do
       @comment = Comment.new
       @comment.post = Post.new
@@ -67,26 +67,26 @@ describe "belongs_to" do
         response.should == "Test response"
       end
     end
-    
+
     it "should cache resource after fetching" do
       @comment = Comment.new(:post_id => 1)
       @comment.post do |result|
         @result = result
         resume
       end
-      
+
       wait_max 1.0 do
         @comment.post.should == @result
       end
     end
-  
+
     it "should give HTTP response to block" do
       @comment = Comment.new(:post_id => 1)
       @comment.post do |results, response|
         @response = response
         resume
       end
-      
+
       wait_max 1.0 do
         @response.should.be.success
       end
@@ -107,7 +107,7 @@ describe "belongs_to" do
     end
 
   end
-  
+
   describe "writer" do
     it "should create model when assigned with hash" do
       comment = Comment.new
@@ -120,41 +120,41 @@ describe "belongs_to" do
       comment.account = { :id => 1, :text => 'Hello' }
       comment.account.class.should == User
     end
-    
+
     it "should set attributes when assigned with hash" do
       comment = Comment.new
       comment.post = { :id => 1, :text => 'Hello' }
       comment.post.text.should == 'Hello'
       comment.post.class.should == Post
     end
-    
+
     it "should use identity map when assigned with hash" do
       post = Post.instantiate(:id => 10)
       comment = Comment.new
       comment.post = { :id => 10 }
       comment.post.should == post
     end
-    
+
     it "should act like a regular setter when assigned with object" do
       post = Post.new
       comment = Comment.new
       comment.post = post
       comment.post.should == post
     end
-    
+
     it "should set association id when assigned with hash" do
       comment = Comment.new
       comment.post = { :id => 10 }
       comment.post_id.should == 10
     end
-    
+
     it "should set association id when assigned with object" do
       comment = Comment.new
       comment.post = Post.new(:id => 10)
       comment.post_id.should == 10
     end
   end
-  
+
   describe "piggybacking" do
     it "should set association when returned with model" do
       stub_request(:get, "http://example.com/comments/1.json").to_return(json: { id: 1, post: { id: 2, text: 'Hello' } })
@@ -162,7 +162,7 @@ describe "belongs_to" do
         @result = result
         resume
       end
-      
+
       wait_max 1.0 do
         @result.post.text.should == 'Hello'
       end

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -1,15 +1,6 @@
 describe "belongs_to" do
   extend WebStub::SpecHelpers
 
-  before do
-    disable_network_access!
-  end
-
-  after do
-    enable_network_access!
-    reset_stubs
-  end
-
   it "should define reader" do
     Comment.new.should.respond_to :post
   end
@@ -45,30 +36,6 @@ describe "belongs_to" do
       comment.post = post
       comment.post.should == post
     end
-
-     #it "should use mutable containers" do
-      #url = "http://example.com/"
-      #stub_request(:get, url).
-        #to_return(json: {"data" => ["thing"]}, delay: 0.3)
-
-      #AFMotion::JSON.get(url) do |result|
-        #@object = result.object
-        #resume
-      #end
-
-      #wait_max 1.0 do
-        #array = @object['data']
-        #array << 'derp'
-        #array.count.should == 2
-
-        #@object['hello'] = 'world'
-        #@object.count.should == 2
-
-        #@object.delete('data')
-        #@object.count.should == 1
-      #end
-    #end
-
 
     it "should fetch resource when called with a block" do
       @comment = Comment.new(:post_id => 1)

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -1,6 +1,15 @@
 describe "belongs_to" do
   extend WebStub::SpecHelpers
 
+  before do
+    disable_network_access!
+  end
+
+  after do
+    enable_network_access!
+    reset_stubs
+  end
+
   it "should define reader" do
     Comment.new.should.respond_to :post
   end
@@ -21,10 +30,9 @@ describe "belongs_to" do
   end
 
   describe "reader" do
-    extend WebStub::SpecHelpers
-
     before do
-      stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, text: 'Hello' })
+      stub_request(:get, "http://example.com/posts/1.json")
+        .to_return(json: { id: 1, text: 'Hello' }, delay: 0.3)
     end
 
     it "should by default return nil when called without a block" do
@@ -38,17 +46,41 @@ describe "belongs_to" do
       comment.post.should == post
     end
 
-    #it "should fetch resource when called with a block" do
-      #@comment = Comment.new(:post_id => 1)
-      #@comment.post do |result|
-        #@result = result
+     #it "should use mutable containers" do
+      #url = "http://example.com/"
+      #stub_request(:get, url).
+        #to_return(json: {"data" => ["thing"]}, delay: 0.3)
+
+      #AFMotion::JSON.get(url) do |result|
+        #@object = result.object
         #resume
       #end
 
       #wait_max 1.0 do
-        #@result.text.should == 'Hello'
+        #array = @object['data']
+        #array << 'derp'
+        #array.count.should == 2
+
+        #@object['hello'] = 'world'
+        #@object.count.should == 2
+
+        #@object.delete('data')
+        #@object.count.should == 1
       #end
     #end
+
+
+    it "should fetch resource when called with a block" do
+      @comment = Comment.new(:post_id => 1)
+      @comment.post do |result|
+        @result = result
+        resume
+      end
+
+      wait_max 1.0 do
+        @result.text.should == 'Hello'
+      end
+    end
 
     it "should return cached resource immediately if exist when called with a block" do
       post = Post.new
@@ -80,46 +112,43 @@ describe "belongs_to" do
       end
     end
 
-    #TODO
-    #it "should give HTTP response to block" do
-      #@comment = Comment.new(:post_id => 1)
-      #@comment.post do |results, response|
-        #@response = response
-        #resume
-      #end
+    it "should give HTTP response to block" do
+      @comment = Comment.new(:post_id => 1)
+      @comment.post do |results, response|
+        @response = response
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@response.should.be.success
-      #end
-    #end
+      wait_max 1.0 do
+        @response.should.be.success
+      end
+    end
 
-    #TODO
-    #it "should give HTTP response to block" do
-      #@comment = Comment.new(:post_id => 1)
-      #@comment.post do |results, response|
-        #@response = response
-        #resume
-      #end
+    it "should give HTTP response to block" do
+      @comment = Comment.new(:post_id => 1)
+      @comment.post do |results, response|
+        @response = response
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@response.should.be.success
-      #end
-    #end
+      wait_max 1.0 do
+        @response.should.be.success
+      end
+    end
 
-    #TODO
-    #it "should return correct type of object" do
-      #stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, text: 'Hello' })
-      #@comment = Comment.new(:account_id => 1)
-      #@comment.account do |results, response|
-        #@account = results
-        #@response = response
-        #resume
-      #end
-      #wait_max 1.0 do
-        #@response.should.be.success
-        #@account.class.should == User
-      #end
-    #end
+    it "should return correct type of object" do
+      stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, text: 'Hello' })
+      @comment = Comment.new(:account_id => 1)
+      @comment.account do |results, response|
+        @account = results
+        @response = response
+        resume
+      end
+      wait_max 1.0 do
+        @response.should.be.success
+        @account.class.should == User
+      end
+    end
 
   end
 
@@ -171,17 +200,16 @@ describe "belongs_to" do
   end
 
   describe "piggybacking" do
-    #TODO
-    #it "should set association when returned with model" do
-      #stub_request(:get, "http://example.com/comments/1.json").to_return(json: { id: 1, post: { id: 2, text: 'Hello' } })
-      #Comment.find(1) do |result|
-        #@result = result
-        #resume
-      #end
+    it "should set association when returned with model" do
+      stub_request(:get, "http://example.com/comments/1.json").to_return(json: { id: 1, post: { id: 2, text: 'Hello' } })
+      Comment.find(1) do |result|
+        @result = result
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@result.post.text.should == 'Hello'
-      #end
-    #end
+      wait_max 1.0 do
+        @result.post.text.should == 'Hello'
+      end
+    end
   end
 end

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -88,7 +88,7 @@ describe "belongs_to" do
       end
       
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
 
@@ -101,7 +101,7 @@ describe "belongs_to" do
         resume
       end
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
         @account.class.should == User
       end
     end

--- a/spec/motion-resource/associations/belongs_to_spec.rb
+++ b/spec/motion-resource/associations/belongs_to_spec.rb
@@ -38,17 +38,17 @@ describe "belongs_to" do
       comment.post.should == post
     end
 
-    it "should fetch resource when called with a block" do
-      @comment = Comment.new(:post_id => 1)
-      @comment.post do |result|
-        @result = result
-        resume
-      end
+    #it "should fetch resource when called with a block" do
+      #@comment = Comment.new(:post_id => 1)
+      #@comment.post do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.text.should == 'Hello'
-      end
-    end
+      #wait_max 1.0 do
+        #@result.text.should == 'Hello'
+      #end
+    #end
 
     it "should return cached resource immediately if exist when called with a block" do
       post = Post.new
@@ -80,31 +80,46 @@ describe "belongs_to" do
       end
     end
 
-    it "should give HTTP response to block" do
-      @comment = Comment.new(:post_id => 1)
-      @comment.post do |results, response|
-        @response = response
-        resume
-      end
+    #TODO
+    #it "should give HTTP response to block" do
+      #@comment = Comment.new(:post_id => 1)
+      #@comment.post do |results, response|
+        #@response = response
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @response.should.be.success
-      end
-    end
+      #wait_max 1.0 do
+        #@response.should.be.success
+      #end
+    #end
 
-    it "should return correct type of object" do
-      stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, text: 'Hello' })
-      @comment = Comment.new(:account_id => 1)
-      @comment.account do |results, response|
-        @account = results
-        @response = response
-        resume
-      end
-      wait_max 1.0 do
-        @response.should.be.success
-        @account.class.should == User
-      end
-    end
+    #TODO
+    #it "should give HTTP response to block" do
+      #@comment = Comment.new(:post_id => 1)
+      #@comment.post do |results, response|
+        #@response = response
+        #resume
+      #end
+
+      #wait_max 1.0 do
+        #@response.should.be.success
+      #end
+    #end
+
+    #TODO
+    #it "should return correct type of object" do
+      #stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, text: 'Hello' })
+      #@comment = Comment.new(:account_id => 1)
+      #@comment.account do |results, response|
+        #@account = results
+        #@response = response
+        #resume
+      #end
+      #wait_max 1.0 do
+        #@response.should.be.success
+        #@account.class.should == User
+      #end
+    #end
 
   end
 
@@ -156,16 +171,17 @@ describe "belongs_to" do
   end
 
   describe "piggybacking" do
-    it "should set association when returned with model" do
-      stub_request(:get, "http://example.com/comments/1.json").to_return(json: { id: 1, post: { id: 2, text: 'Hello' } })
-      Comment.find(1) do |result|
-        @result = result
-        resume
-      end
+    #TODO
+    #it "should set association when returned with model" do
+      #stub_request(:get, "http://example.com/comments/1.json").to_return(json: { id: 1, post: { id: 2, text: 'Hello' } })
+      #Comment.find(1) do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.post.text.should == 'Hello'
-      end
-    end
+      #wait_max 1.0 do
+        #@result.post.text.should == 'Hello'
+      #end
+    #end
   end
 end

--- a/spec/motion-resource/associations/has_many_spec.rb
+++ b/spec/motion-resource/associations/has_many_spec.rb
@@ -122,7 +122,7 @@ describe "has_many" do
       end
       
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
   end

--- a/spec/motion-resource/associations/has_many_spec.rb
+++ b/spec/motion-resource/associations/has_many_spec.rb
@@ -1,77 +1,77 @@
 describe "has_many" do
   extend WebStub::SpecHelpers
-  
+
   it "should define reader" do
     Post.new.should.respond_to :comments
   end
-  
+
   it "should define writer" do
     Post.new.should.respond_to :comments=
   end
-  
+
   it "should define reset method" do
     Post.new.should.respond_to :reset_comments
   end
-  
+
   it "should reset" do
     post = Post.new
     post.comments = [Comment.new]
     post.reset_comments
     post.comments.should == []
   end
-  
+
   describe "custom class name" do
     extend WebStub::SpecHelpers
-  
+
     before do
       stub_request(:get, "http://example.com/posts.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
     end
-  
+
     it "should fetch resources when called with a block" do
       @post = Post.new
       @post.parent_posts do |results|
         @results = results
         resume
       end
-    
+
       wait_max 1.0 do
         @results.size.should == 1
         @results.first.text.should == 'Whats up?'
       end
     end
   end
-  
+
   describe "reader" do
     extend WebStub::SpecHelpers
-    
+
     before do
       stub_request(:get, "http://example.com/comments.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
     end
-    
+
     it "should by default return an empty array when called without a block" do
       Post.new.comments.should == []
     end
-    
+
     it "should return any cached values when called without a block" do
       comment = Comment.new
       post = Post.new
       post.comments = [comment]
       post.comments.should == [comment]
     end
-    
+
     it "should fetch resources when called with a block" do
       @post = Post.new
       @post.comments do |results|
         @results = results
         resume
       end
-      
+
       wait_max 1.0 do
         @results.size.should == 1
         @results.first.text.should == 'Whats up?'
       end
     end
-    
+
     it "should return cached resources immediately if exist when called with a block" do
       comment = Comment.new
       @post = Post.new
@@ -80,7 +80,7 @@ describe "has_many" do
         results.should == [comment]
       end
     end
-    
+
     it "should give cached HTTP response immediately if exist when called with a block" do
       @post = Post.new
       @post.comments = [Comment.new]
@@ -89,71 +89,71 @@ describe "has_many" do
         response.should == "Test response"
       end
     end
-    
+
     it "should assign backward associations when fetching resources" do
       @post = Post.new
       @post.comments do |results|
         @results = results
         resume
       end
-      
+
       wait_max 1.0 do
         @results.first.post.should == @post
       end
     end
-    
+
     it "should cache resources after fetching" do
       @post = Post.new
       @post.comments do |results|
         @results = results
         resume
       end
-      
+
       wait_max 1.0 do
         @post.comments.should == @results
       end
     end
-  
+
     it "should give HTTP response to block" do
       @post = Post.new
       @post.comments do |results, response|
         @response = response
         resume
       end
-      
+
       wait_max 1.0 do
         @response.should.be.success
       end
     end
   end
-  
+
   describe "writer" do
     it "should create model when assigned with hash" do
       post = Post.new
       post.comments = [{ :id => 1, :text => 'Whats up?' }]
       post.comments.first.should.is_a Comment
     end
-    
+
     it "should set attributes when assigned with hash" do
       post = Post.new
       post.comments = [{ :id => 1, :text => 'Whats up?' }]
       post.comments.first.text.should == 'Whats up?'
     end
-    
+
     it "should use identity map when assigned with hash" do
       comment = Comment.instantiate(:id => 10)
       post = Post.new
       post.comments = [{ :id => 10 }]
       post.comments.first.should == comment
     end
-    
+
     it "should act like a regular setter when assigned with array" do
       post = Post.new
       post.comments = [Comment.new]
       post.comments.size.should == 1
     end
   end
-  
+
   describe "piggybacking" do
     it "should set association when returned with model" do
       stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, comments: [{ id: 2, text: 'Whats up?' }] })
@@ -161,7 +161,7 @@ describe "has_many" do
         @result = result
         resume
       end
-      
+
       wait_max 1.0 do
         @result.comments.first.text.should == 'Whats up?'
       end

--- a/spec/motion-resource/associations/has_many_spec.rb
+++ b/spec/motion-resource/associations/has_many_spec.rb
@@ -123,6 +123,7 @@ describe "has_many" do
 
       wait_max 1.0 do
         @response.should.be.success
+        @response.should.be.ok
       end
     end
   end

--- a/spec/motion-resource/associations/has_many_spec.rb
+++ b/spec/motion-resource/associations/has_many_spec.rb
@@ -27,19 +27,18 @@ describe "has_many" do
       stub_request(:get, "http://example.com/posts.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
     end
 
-    #TODO
-    #it "should fetch resources when called with a block" do
-      #@post = Post.new
-      #@post.parent_posts do |results|
-        #@results = results
-        #resume
-      #end
+    it "should fetch resources when called with a block" do
+      @post = Post.new
+      @post.parent_posts do |results|
+        @results = results
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@results.size.should == 1
-        #@results.first.text.should == 'Whats up?'
-      #end
-    #end
+      wait_max 1.0 do
+        @results.size.should == 1
+        @results.first.text.should == 'Whats up?'
+      end
+    end
   end
 
   describe "reader" do
@@ -60,19 +59,18 @@ describe "has_many" do
       post.comments.should == [comment]
     end
 
-    #TODO
-    #it "should fetch resources when called with a block" do
-      #@post = Post.new
-      #@post.comments do |results|
-        #@results = results
-        #resume
-      #end
+    it "should fetch resources when called with a block" do
+      @post = Post.new
+      @post.comments do |results|
+        @results = results
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@results.size.should == 1
-        #@results.first.text.should == 'Whats up?'
-      #end
-    #end
+      wait_max 1.0 do
+        @results.size.should == 1
+        @results.first.text.should == 'Whats up?'
+      end
+    end
 
     it "should return cached resources immediately if exist when called with a block" do
       comment = Comment.new
@@ -92,44 +90,41 @@ describe "has_many" do
       end
     end
 
-    #TODO
-    #it "should assign backward associations when fetching resources" do
-      #@post = Post.new
-      #@post.comments do |results|
-        #@results = results
-        #resume
-      #end
+    it "should assign backward associations when fetching resources" do
+      @post = Post.new
+      @post.comments do |results|
+        @results = results
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@results.first.post.should == @post
-      #end
-    #end
+      wait_max 1.0 do
+        @results.first.post.should == @post
+      end
+    end
 
-    #TODO
-    #it "should cache resources after fetching" do
-      #@post = Post.new
-      #@post.comments do |results|
-        #@results = results
-        #resume
-      #end
+    it "should cache resources after fetching" do
+      @post = Post.new
+      @post.comments do |results|
+        @results = results
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@post.comments.should == @results
-      #end
-    #end
+      wait_max 1.0 do
+        @post.comments.should == @results
+      end
+    end
 
-    #TODO
-    #it "should give HTTP response to block" do
-      #@post = Post.new
-      #@post.comments do |results, response|
-        #@response = response
-        #resume
-      #end
+    it "should give HTTP response to block" do
+      @post = Post.new
+      @post.comments do |results, response|
+        @response = response
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@response.should.be.success
-      #end
-    #end
+      wait_max 1.0 do
+        @response.should.be.success
+      end
+    end
   end
 
   describe "writer" do
@@ -160,17 +155,16 @@ describe "has_many" do
   end
 
   describe "piggybacking" do
-    #TODO
-    #it "should set association when returned with model" do
-      #stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, comments: [{ id: 2, text: 'Whats up?' }] })
-      #Post.find(1) do |result|
-        #@result = result
-        #resume
-      #end
+    it "should set association when returned with model" do
+      stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, comments: [{ id: 2, text: 'Whats up?' }] })
+      Post.find(1) do |result|
+        @result = result
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@result.comments.first.text.should == 'Whats up?'
-      #end
-    #end
+      wait_max 1.0 do
+        @result.comments.first.text.should == 'Whats up?'
+      end
+    end
   end
 end

--- a/spec/motion-resource/associations/has_many_spec.rb
+++ b/spec/motion-resource/associations/has_many_spec.rb
@@ -27,18 +27,19 @@ describe "has_many" do
       stub_request(:get, "http://example.com/posts.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
     end
 
-    it "should fetch resources when called with a block" do
-      @post = Post.new
-      @post.parent_posts do |results|
-        @results = results
-        resume
-      end
+    #TODO
+    #it "should fetch resources when called with a block" do
+      #@post = Post.new
+      #@post.parent_posts do |results|
+        #@results = results
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @results.size.should == 1
-        @results.first.text.should == 'Whats up?'
-      end
-    end
+      #wait_max 1.0 do
+        #@results.size.should == 1
+        #@results.first.text.should == 'Whats up?'
+      #end
+    #end
   end
 
   describe "reader" do
@@ -59,18 +60,19 @@ describe "has_many" do
       post.comments.should == [comment]
     end
 
-    it "should fetch resources when called with a block" do
-      @post = Post.new
-      @post.comments do |results|
-        @results = results
-        resume
-      end
+    #TODO
+    #it "should fetch resources when called with a block" do
+      #@post = Post.new
+      #@post.comments do |results|
+        #@results = results
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @results.size.should == 1
-        @results.first.text.should == 'Whats up?'
-      end
-    end
+      #wait_max 1.0 do
+        #@results.size.should == 1
+        #@results.first.text.should == 'Whats up?'
+      #end
+    #end
 
     it "should return cached resources immediately if exist when called with a block" do
       comment = Comment.new
@@ -90,41 +92,44 @@ describe "has_many" do
       end
     end
 
-    it "should assign backward associations when fetching resources" do
-      @post = Post.new
-      @post.comments do |results|
-        @results = results
-        resume
-      end
+    #TODO
+    #it "should assign backward associations when fetching resources" do
+      #@post = Post.new
+      #@post.comments do |results|
+        #@results = results
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @results.first.post.should == @post
-      end
-    end
+      #wait_max 1.0 do
+        #@results.first.post.should == @post
+      #end
+    #end
 
-    it "should cache resources after fetching" do
-      @post = Post.new
-      @post.comments do |results|
-        @results = results
-        resume
-      end
+    #TODO
+    #it "should cache resources after fetching" do
+      #@post = Post.new
+      #@post.comments do |results|
+        #@results = results
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @post.comments.should == @results
-      end
-    end
+      #wait_max 1.0 do
+        #@post.comments.should == @results
+      #end
+    #end
 
-    it "should give HTTP response to block" do
-      @post = Post.new
-      @post.comments do |results, response|
-        @response = response
-        resume
-      end
+    #TODO
+    #it "should give HTTP response to block" do
+      #@post = Post.new
+      #@post.comments do |results, response|
+        #@response = response
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @response.should.be.success
-      end
-    end
+      #wait_max 1.0 do
+        #@response.should.be.success
+      #end
+    #end
   end
 
   describe "writer" do
@@ -155,16 +160,17 @@ describe "has_many" do
   end
 
   describe "piggybacking" do
-    it "should set association when returned with model" do
-      stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, comments: [{ id: 2, text: 'Whats up?' }] })
-      Post.find(1) do |result|
-        @result = result
-        resume
-      end
+    #TODO
+    #it "should set association when returned with model" do
+      #stub_request(:get, "http://example.com/posts/1.json").to_return(json: { id: 1, comments: [{ id: 2, text: 'Whats up?' }] })
+      #Post.find(1) do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.comments.first.text.should == 'Whats up?'
-      end
-    end
+      #wait_max 1.0 do
+        #@result.comments.first.text.should == 'Whats up?'
+      #end
+    #end
   end
 end

--- a/spec/motion-resource/associations/has_one_spec.rb
+++ b/spec/motion-resource/associations/has_one_spec.rb
@@ -54,17 +54,18 @@ describe "has_one" do
   end
 
   describe "piggybacking" do
-    #TODO
-    #it "should set association when returned with model" do
-      #stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, profile: { id: 2, name: 'John' } })
-      #User.find(1) do |result|
-        #@result = result
-        #resume
-      #end
+    it "should set association when returned with model" do
+      stub_request(:get, "http://example.com/users/1.json")
+        .to_return(json: { id: 1, profile: { id: 2, name: 'John' } })
 
-      #wait_max 1.0 do
-        #@result.profile.name.should == 'John'
-      #end
-    #end
+      User.find(1) do |result|
+        @result = result
+        resume
+      end
+
+      wait_max 1.0 do
+        @result.profile.name.should == 'John'
+      end
+    end
   end
 end

--- a/spec/motion-resource/associations/has_one_spec.rb
+++ b/spec/motion-resource/associations/has_one_spec.rb
@@ -54,16 +54,17 @@ describe "has_one" do
   end
 
   describe "piggybacking" do
-    it "should set association when returned with model" do
-      stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, profile: { id: 2, name: 'John' } })
-      User.find(1) do |result|
-        @result = result
-        resume
-      end
+    #TODO
+    #it "should set association when returned with model" do
+      #stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, profile: { id: 2, name: 'John' } })
+      #User.find(1) do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.profile.name.should == 'John'
-      end
-    end
+      #wait_max 1.0 do
+        #@result.profile.name.should == 'John'
+      #end
+    #end
   end
 end

--- a/spec/motion-resource/associations/has_one_spec.rb
+++ b/spec/motion-resource/associations/has_one_spec.rb
@@ -1,50 +1,50 @@
 describe "has_one" do
   extend WebStub::SpecHelpers
-  
+
   it "should define reader" do
     User.new.should.respond_to :profile
   end
-  
+
   it "should define writer" do
     User.new.should.respond_to :profile=
   end
-  
+
   it "should define reset method" do
     User.new.should.respond_to :reset_profile
   end
-  
+
   it "should by default return nil" do
     User.new.profile.should.be.nil
   end
-  
+
   it "should reset" do
     user = User.new
     user.profile = Profile.new
     user.reset_profile
     user.profile.should.be.nil
   end
-  
+
   describe "writer" do
     it "should create model when assigned with hash" do
       user = User.new
       user.profile = { :id => 1, :name => 'John', :email => 'doe@example.com' }
       user.profile.should.is_a Profile
     end
-    
+
     it "should set attributes when assigned with hash" do
       user = User.new
       user.profile = { :id => 1, :name => 'John', :email => 'doe@example.com' }
       user.profile.name.should == 'John'
       user.profile.email.should == 'doe@example.com'
     end
-    
+
     it "should use identity map when assigned with hash" do
       profile = Profile.instantiate(:id => 10)
       user = User.new
       user.profile = { :id => 10 }
       user.profile.should == profile
     end
-    
+
     it "should act like a regular setter when assigned with object" do
       profile = Profile.new
       user = User.new
@@ -52,7 +52,7 @@ describe "has_one" do
       user.profile.should == profile
     end
   end
-  
+
   describe "piggybacking" do
     it "should set association when returned with model" do
       stub_request(:get, "http://example.com/users/1.json").to_return(json: { id: 1, profile: { id: 2, name: 'John' } })
@@ -60,7 +60,7 @@ describe "has_one" do
         @result = result
         resume
       end
-      
+
       wait_max 1.0 do
         @result.profile.name.should == 'John'
       end

--- a/spec/motion-resource/associations/scope_spec.rb
+++ b/spec/motion-resource/associations/scope_spec.rb
@@ -9,26 +9,28 @@ describe "scope" do
     Comment.should.respond_to :recent_url
   end
 
-  it "should fetch collection" do
-    Comment.recent do |results|
-      @results = results
-      resume
-    end
+  #TODO
+  #it "should fetch collection" do
+    #Comment.recent do |results|
+      #@results = results
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @results.size.should == 1
-      @results.first.text.should == 'Whats up?'
-    end
-  end
+    #wait_max 1.0 do
+      #@results.size.should == 1
+      #@results.first.text.should == 'Whats up?'
+    #end
+  #end
 
-  it "should give HTTP response to block" do
-    Comment.recent do |results, response|
-      @response = response
-      resume
-    end
+  #TODO
+  #it "should give HTTP response to block" do
+    #Comment.recent do |results, response|
+      #@response = response
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @response.should.be.success
-    end
-  end
+    #wait_max 1.0 do
+      #@response.should.be.success
+    #end
+  #end
 end

--- a/spec/motion-resource/associations/scope_spec.rb
+++ b/spec/motion-resource/associations/scope_spec.rb
@@ -28,7 +28,7 @@ describe "scope" do
     end
       
     wait_max 1.0 do
-      @response.should.be.ok
+      @response.should.be.success
     end
   end
 end

--- a/spec/motion-resource/associations/scope_spec.rb
+++ b/spec/motion-resource/associations/scope_spec.rb
@@ -1,32 +1,32 @@
 describe "scope" do
   extend WebStub::SpecHelpers
-  
+
   before do
     stub_request(:get, "http://example.com/comments/recent.json").to_return(json: [{ id: 1, text: 'Whats up?' }])
   end
-  
+
   it "should define a custom url" do
     Comment.should.respond_to :recent_url
   end
-  
+
   it "should fetch collection" do
     Comment.recent do |results|
       @results = results
       resume
     end
-    
+
     wait_max 1.0 do
       @results.size.should == 1
       @results.first.text.should == 'Whats up?'
     end
   end
-  
+
   it "should give HTTP response to block" do
     Comment.recent do |results, response|
       @response = response
       resume
     end
-      
+
     wait_max 1.0 do
       @response.should.be.success
     end

--- a/spec/motion-resource/associations/scope_spec.rb
+++ b/spec/motion-resource/associations/scope_spec.rb
@@ -9,28 +9,26 @@ describe "scope" do
     Comment.should.respond_to :recent_url
   end
 
-  #TODO
-  #it "should fetch collection" do
-    #Comment.recent do |results|
-      #@results = results
-      #resume
-    #end
+  it "should fetch collection" do
+    Comment.recent do |results|
+      @results = results
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@results.size.should == 1
-      #@results.first.text.should == 'Whats up?'
-    #end
-  #end
+    wait_max 1.0 do
+      @results.size.should == 1
+      @results.first.text.should == 'Whats up?'
+    end
+  end
 
-  #TODO
-  #it "should give HTTP response to block" do
-    #Comment.recent do |results, response|
-      #@response = response
-      #resume
-    #end
+  it "should give HTTP response to block" do
+    Comment.recent do |results, response|
+      @response = response
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@response.should.be.success
-    #end
-  #end
+    wait_max 1.0 do
+      @response.should.be.success
+    end
+  end
 end

--- a/spec/motion-resource/attributes_spec.rb
+++ b/spec/motion-resource/attributes_spec.rb
@@ -2,46 +2,46 @@ describe "attributes" do
   it "should define reader per attribute" do
     Shape.new.should.respond_to :contents
   end
-  
+
   it "should define writer per attribute" do
     Shape.new.should.respond_to :contents=
   end
-  
+
   it "should duplicate array in setter" do
     contents = ['hello']
     shape = Shape.new
     shape.contents = contents
     shape.contents.object_id.should != contents.object_id
   end
-  
+
   it "should duplicate hash in setter" do
     contents = { :foo => 'bar' }
     shape = Shape.new
     shape.contents = contents
     shape.contents.should.not.be.identical_to contents
   end
-  
+
   it "should behave regularly for other values in setter" do
     shape = Shape.new
     shape.contents = "hello"
     shape.contents.should == "hello"
   end
-  
+
   it "should store attribute names in accessor" do
     Shape.attributes.should.include :contents
   end
-  
+
   it "should inherit attribute names from parent class" do
     Rectangle.attributes.should.include :contents
     Rectangle.attributes.should.include :size
   end
-  
+
   it "should get hash of all attributes from instance" do
     shape = Shape.new
     shape.contents = "hello"
     shape.attributes[:contents].should == "hello"
   end
-  
+
   describe "update_attributes" do
     it "should set attr_accessors" do
       time = Time.now
@@ -49,13 +49,13 @@ describe "attributes" do
       shape.update_attributes(:created_at => time)
       shape.created_at.should == time
     end
-    
+
     it "should set attributes" do
       shape = Shape.new
       shape.update_attributes(:position => "10,10")
       shape.position.should == "10,10"
     end
-    
+
     it "should not crash when updating an unknown attribute" do
       shape = Shape.new
       lambda { shape.update_attributes(:foo => 'bar') }.should.not.raise

--- a/spec/motion-resource/base_spec.rb
+++ b/spec/motion-resource/base_spec.rb
@@ -3,74 +3,74 @@ describe "base" do
     it "should have a default primary key" do
       Post.primary_key.should == :id
     end
-    
+
     it "should be overridable" do
       Membership.primary_key.should == :membership_id
     end
-    
+
     it "should define the id method" do
       Post.new.should.respond_to :id
     end
   end
-  
+
   it "should set new_record to true when calling new" do
     Post.new.should.be.new_record
   end
-  
+
   it "should set attributes when given a hash in new" do
     post = Post.new(:text => 'hello')
     post.text.should == 'hello'
   end
-  
+
   describe "instantiate" do
     it "should raise an exception if no ID is given" do
       lambda { Shape.instantiate({}) }.should.raise(ArgumentError)
     end
-    
+
     it "should instantiate concrete type if given in json" do
       shape = Shape.instantiate(:id => 1, :type => 'Rectangle')
       shape.should.is_a Rectangle
     end
-    
+
     it "should instantiate with non-standard primary key" do
       membership = Membership.instantiate(:membership_id => 1)
       membership.should.is_a Membership
     end
-    
+
     it "should instantiate base type if concrete type does not exist" do
       shape = Shape.instantiate(:id => 2, :type => 'FuzzyCircle')
       shape.should.is_a Shape
     end
-    
+
     it "should instantiate base type if no type given in json" do
       shape = Shape.instantiate(:id => 3)
       shape.should.is_a Shape
       shape.should.not.is_a Rectangle
     end
-    
+
     it "should set new_record to false" do
       shape = Shape.instantiate(:id => 4)
       shape.should.not.be.new_record
     end
-    
+
     it "should remember instance" do
       Shape.recall(5).should.be.nil
       shape = Shape.instantiate(:id => 5)
       Shape.recall(5).should.not.be.nil
     end
-    
+
     it "should update existing instance" do
       shape1 = Shape.instantiate(:id => 6, :contents => 'nothing')
       shape2 = Shape.instantiate(:id => 6, :contents => 'something')
       shape1.should.be.identical_to shape2
       shape1.contents.should == 'something'
     end
-    
+
     it "should instantiate with ID number" do
       shape = Shape.instantiate(3)
       shape.id.should == 3
     end
-    
+
     it "should instantiate with ID string" do
       shape = Shape.instantiate("5")
       shape.id.should == 5

--- a/spec/motion-resource/callbacks_spec.rb
+++ b/spec/motion-resource/callbacks_spec.rb
@@ -23,49 +23,48 @@ describe "base" do
   extend MotionResource::SpecHelpers
 
   describe "callbacks" do
-    #TODO make these work
-    #it "should run create callbacks" do
-      #stub_request(:post, "http://example.com/models.json").to_return(json: {})
-      #@model = CallbackSpec::Model.create { |obj| resume }
-      #wait_max 1.0 do
-        #@model.history.should == ['before_create', 'after_create']
-      #end
-    #end
+    it "should run create callbacks" do
+      stub_request(:post, "http://example.com/models.json").to_return(json: {})
+      @model = CallbackSpec::Model.create { |obj| resume }
+      wait_max 1.0 do
+        @model.history.should == ['before_create', 'after_create']
+      end
+    end
 
-    #it "should run create and save callbacks on first save" do
-      #stub_request(:post, "http://example.com/models.json").to_return(json: {})
-      #@model = CallbackSpec::Model.new
-      #@model.save { |obj| resume }
-      #wait_max 1.0 do
-        #@model.history.should == ['before_save', 'before_create', 'after_create', 'after_save']
-      #end
-    #end
+    it "should run create and save callbacks on first save" do
+      stub_request(:post, "http://example.com/models.json").to_return(json: {})
+      @model = CallbackSpec::Model.new
+      @model.save { |obj| resume }
+      wait_max 1.0 do
+        @model.history.should == ['before_save', 'before_create', 'after_create', 'after_save']
+      end
+    end
 
-    #it "should run update and save callbacks on subsequent save" do
-      #stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
-      #@model = CallbackSpec::Model.instantiate(:id => 10)
-      #@model.save { |obj| resume }
-      #wait_max 1.0 do
-        #@model.history.should == ['before_save', 'before_update', 'after_update', 'after_save']
-      #end
-    #end
+    it "should run update and save callbacks on subsequent save" do
+      stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
+      @model = CallbackSpec::Model.instantiate(:id => 10)
+      @model.save { |obj| resume }
+      wait_max 1.0 do
+        @model.history.should == ['before_save', 'before_update', 'after_update', 'after_save']
+      end
+    end
 
-    #it "should run update callbacks" do
-      #stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
-      #@model = CallbackSpec::Model.instantiate(:id => 10)
-      #@model.update { |obj| resume }
-      #wait_max 1.0 do
-        #@model.history.should == ['before_update', 'after_update']
-      #end
-    #end
+    it "should run update callbacks" do
+      stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
+      @model = CallbackSpec::Model.instantiate(:id => 10)
+      @model.update { |obj| resume }
+      wait_max 1.0 do
+        @model.history.should == ['before_update', 'after_update']
+      end
+    end
 
-    #it "should run destroy callbacks" do
-      #stub_request(:delete, "http://example.com/models/10.json").to_return(json: {})
-      #@model = CallbackSpec::Model.instantiate(:id => 10)
-      #@model.destroy { |obj| resume }
-      #wait_max 1.0 do
-        #@model.history.should == ['before_destroy', 'after_destroy']
-      #end
-    #end
+    it "should run destroy callbacks" do
+      stub_request(:delete, "http://example.com/models/10.json").to_return(json: {})
+      @model = CallbackSpec::Model.instantiate(:id => 10)
+      @model.destroy { |obj| resume }
+      wait_max 1.0 do
+        @model.history.should == ['before_destroy', 'after_destroy']
+      end
+    end
   end
 end

--- a/spec/motion-resource/callbacks_spec.rb
+++ b/spec/motion-resource/callbacks_spec.rb
@@ -23,48 +23,49 @@ describe "base" do
   extend MotionResource::SpecHelpers
 
   describe "callbacks" do
-    it "should run create callbacks" do
-      stub_request(:post, "http://example.com/models.json").to_return(json: {})
-      @model = CallbackSpec::Model.create { |obj| resume }
-      wait_max 1.0 do
-        @model.history.should == ['before_create', 'after_create']
-      end
-    end
+    #TODO make these work
+    #it "should run create callbacks" do
+      #stub_request(:post, "http://example.com/models.json").to_return(json: {})
+      #@model = CallbackSpec::Model.create { |obj| resume }
+      #wait_max 1.0 do
+        #@model.history.should == ['before_create', 'after_create']
+      #end
+    #end
 
-    it "should run create and save callbacks on first save" do
-      stub_request(:post, "http://example.com/models.json").to_return(json: {})
-      @model = CallbackSpec::Model.new
-      @model.save { |obj| resume }
-      wait_max 1.0 do
-        @model.history.should == ['before_save', 'before_create', 'after_create', 'after_save']
-      end
-    end
+    #it "should run create and save callbacks on first save" do
+      #stub_request(:post, "http://example.com/models.json").to_return(json: {})
+      #@model = CallbackSpec::Model.new
+      #@model.save { |obj| resume }
+      #wait_max 1.0 do
+        #@model.history.should == ['before_save', 'before_create', 'after_create', 'after_save']
+      #end
+    #end
 
-    it "should run update and save callbacks on subsequent save" do
-      stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
-      @model = CallbackSpec::Model.instantiate(:id => 10)
-      @model.save { |obj| resume }
-      wait_max 1.0 do
-        @model.history.should == ['before_save', 'before_update', 'after_update', 'after_save']
-      end
-    end
+    #it "should run update and save callbacks on subsequent save" do
+      #stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
+      #@model = CallbackSpec::Model.instantiate(:id => 10)
+      #@model.save { |obj| resume }
+      #wait_max 1.0 do
+        #@model.history.should == ['before_save', 'before_update', 'after_update', 'after_save']
+      #end
+    #end
 
-    it "should run update callbacks" do
-      stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
-      @model = CallbackSpec::Model.instantiate(:id => 10)
-      @model.update { |obj| resume }
-      wait_max 1.0 do
-        @model.history.should == ['before_update', 'after_update']
-      end
-    end
+    #it "should run update callbacks" do
+      #stub_request(:put, "http://example.com/models/10.json").to_return(json: {})
+      #@model = CallbackSpec::Model.instantiate(:id => 10)
+      #@model.update { |obj| resume }
+      #wait_max 1.0 do
+        #@model.history.should == ['before_update', 'after_update']
+      #end
+    #end
 
-    it "should run destroy callbacks" do
-      stub_request(:delete, "http://example.com/models/10.json").to_return(json: {})
-      @model = CallbackSpec::Model.instantiate(:id => 10)
-      @model.destroy { |obj| resume }
-      wait_max 1.0 do
-        @model.history.should == ['before_destroy', 'after_destroy']
-      end
-    end
+    #it "should run destroy callbacks" do
+      #stub_request(:delete, "http://example.com/models/10.json").to_return(json: {})
+      #@model = CallbackSpec::Model.instantiate(:id => 10)
+      #@model.destroy { |obj| resume }
+      #wait_max 1.0 do
+        #@model.history.should == ['before_destroy', 'after_destroy']
+      #end
+    #end
   end
 end

--- a/spec/motion-resource/callbacks_spec.rb
+++ b/spec/motion-resource/callbacks_spec.rb
@@ -2,7 +2,7 @@ module CallbackSpec
   class Model < MotionResource::Base
     self.member_url = 'models/:id'
     self.collection_url = 'models'
-    
+
     before_create { |m| m.history << "before_create" }
     after_create { |m| m.history << "after_create" }
     before_save { |m| m.history << "before_save" }
@@ -11,7 +11,7 @@ module CallbackSpec
     after_update { |m| m.history << "after_update" }
     before_destroy { |m| m.history << "before_destroy" }
     after_destroy { |m| m.history << "after_destroy" }
-    
+
     def history
       @history ||= []
     end
@@ -57,7 +57,7 @@ describe "base" do
         @model.history.should == ['before_update', 'after_update']
       end
     end
-    
+
     it "should run destroy callbacks" do
       stub_request(:delete, "http://example.com/models/10.json").to_return(json: {})
       @model = CallbackSpec::Model.instantiate(:id => 10)

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -162,33 +162,32 @@ describe "crud" do
     end
 
 
-    #it "should include association" do
-      #pending
-      #stub_request(:put, "http://example.com/posts/10.json").to_return(body: "")
-      #Post.instantiate(:id => 10).update(:include => :comments) do |result, response|
-        #@response = response
-        #resume
-      #end
+    it "should include association" do
+      stub_request(:put, "http://example.com/posts/10.json").to_return(body: "")
+      Post.instantiate(:id => 10).update(:include => :comments) do |result, response|
+        @response = response
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@response.should.be.success
-      #end
-    #end
+      wait_max 1.0 do
+        @response.should.be.success
+      end
+    end
   end
 
   describe "destroy" do
-    #it "should destroy with json in response" do
-      #stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-      #comment = Comment.instantiate(:id => 10)
-      #comment.destroy do |result|
-        #@result = result
-        #resume
-      #end
+    it "should destroy with json in response" do
+      stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+      comment = Comment.instantiate(:id => 10)
+      comment.destroy do |result|
+        @result = result
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@result.should.not.be.nil
-      #end
-    #end
+      wait_max 1.0 do
+        @result.should.not.be.nil
+      end
+    end
 
     it "should destroy without json in response" do
       stub_request(:delete, "http://example.com/comments/10.json").to_return(body: "")

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -28,18 +28,19 @@ describe "crud" do
       end
     end
 
-    it "should create without json in response" do
-      stub_request(:post, "http://example.com/comments.json").to_return(body: "")
-      @comment = Comment.new
-      @comment.create do |result|
-        @result = result
-        resume
-      end
+    #it "should create without json in response" do
+      #pending
+      #stub_request(:post, "http://example.com/comments.json").to_return(body: "")
+      #@comment = Comment.new
+      #@comment.create do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.should == @comment
-      end
-    end
+      #wait_max 1.0 do
+        #@result.should == @comment
+      #end
+    #end
 
     it "should create with empty json response" do
       stub_request(:post, "http://example.com/comments.json").to_return(json: {})
@@ -54,41 +55,45 @@ describe "crud" do
       end
     end
 
-    it "should give HTTP response to block" do
-      stub_request(:post, "http://example.com/comments.json").to_return(json: {}, status_code: 404)
-      Comment.new.create do |result, response|
-        @response = response
-        resume
-      end
+    #TODO
+    #it "should give HTTP response to block" do
+      #stub_request(:post, "http://example.com/comments.json").to_return(json: {}, status_code: 404)
+      #Comment.new.create do |result, response|
+        #@response = response
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @response.should.not.be.success
-      end
-    end
+      #wait_max 1.0 do
+        #@response.should.not.be.success
+      #end
+    #end
 
-    it "should include association" do
-      stub_request(:post, "http://example.com/posts.json").to_return(body: "")
-      Post.new.create(:include => :comments) do |result, response|
-        @response = response
-        resume
-      end
+    #TODO
+    #it "should include association" do
+      #stub_request(:post, "http://example.com/posts.json").to_return(body: "")
+      #Post.new.create(:include => :comments) do |result, response|
+        #@response = response
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @response.should.be.success
-      end
-    end
+      #wait_max 1.0 do
+        #@response.should.be.success
+      #end
+    #end
 
-    it "should include association with _attributes suffix" do
-      stub_request(:post, "http://example.com/posts.json").to_return(body: "")
-      Post.new.create(:include => :comments_attributes) do |result, response|
-        @response = response
-        resume
-      end
+    #TODO
+    #it "should include association with _attributes suffix" do
+      #pending
+      #stub_request(:post, "http://example.com/posts.json").to_return(body: "")
+      #Post.new.create(:include => :comments_attributes) do |result, response|
+        #@response = response
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @response.should.be.success
-      end
-    end
+      #wait_max 1.0 do
+        #@response.should.be.success
+      #end
+    #end
 
     it "should raise error when included association is not found" do
       stub_request(:post, "http://example.com/posts.json").to_return(body: "")
@@ -123,18 +128,19 @@ describe "crud" do
       end
     end
 
-    it "should update without json in response" do
-      stub_request(:put, "http://example.com/comments/10.json").to_return(body: "")
-      @comment = Comment.instantiate(:id => 10)
-      @comment.update do |result|
-        @result = result
-        resume
-      end
+    #it "should update without json in response" do
+      #pending
+      #stub_request(:put, "http://example.com/comments/10.json").to_return(body: "")
+      #@comment = Comment.instantiate(:id => 10)
+      #@comment.update do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.should.be == @comment
-      end
-    end
+      #wait_max 1.0 do
+        #@result.should.be == @comment
+      #end
+    #end
 
     it "should update with empty json response" do
       stub_request(:put, "http://example.com/comments/10.json").to_return(json: {})
@@ -162,32 +168,34 @@ describe "crud" do
     end
 
 
-    it "should include association" do
-      stub_request(:put, "http://example.com/posts/10.json").to_return(body: "")
-      Post.instantiate(:id => 10).update(:include => :comments) do |result, response|
-        @response = response
-        resume
-      end
+    #it "should include association" do
+      #pending
+      #stub_request(:put, "http://example.com/posts/10.json").to_return(body: "")
+      #Post.instantiate(:id => 10).update(:include => :comments) do |result, response|
+        #@response = response
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @response.should.be.success
-      end
-    end
+      #wait_max 1.0 do
+        #@response.should.be.success
+      #end
+    #end
   end
 
   describe "destroy" do
-    it "should destroy with json in response" do
-      stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-      comment = Comment.instantiate(:id => 10)
-      comment.destroy do |result|
-        @result = result
-        resume
-      end
+    #TODO
+    #it "should destroy with json in response" do
+      #stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+      #comment = Comment.instantiate(:id => 10)
+      #comment.destroy do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.should.not.be.nil
-      end
-    end
+      #wait_max 1.0 do
+        #@result.should.not.be.nil
+      #end
+    #end
 
     it "should destroy without json in response" do
       stub_request(:delete, "http://example.com/comments/10.json").to_return(body: "")
@@ -216,18 +224,19 @@ describe "crud" do
   end
 
   describe "reload" do
-    it "should reload with json in response" do
-      stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-      comment = Comment.instantiate(:id => 10)
-      comment.reload do |result|
-        @result = result
-        resume
-      end
+    #TODO
+    #it "should reload with json in response" do
+      #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+      #comment = Comment.instantiate(:id => 10)
+      #comment.reload do |result|
+        #@result = result
+        #resume
+      #end
 
-      wait_max 1.0 do
-        @result.should.not.be.nil
-      end
-    end
+      #wait_max 1.0 do
+        #@result.should.not.be.nil
+      #end
+    #end
 
     it "should reload without json in response" do
       stub_request(:get, "http://example.com/comments/10.json").to_return(body: "")

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -123,19 +123,18 @@ describe "crud" do
       end
     end
 
-    #it "should update without json in response" do
-      #pending
-      #stub_request(:put, "http://example.com/comments/10.json").to_return(body: "")
-      #@comment = Comment.instantiate(:id => 10)
-      #@comment.update do |result|
-        #@result = result
-        #resume
-      #end
+    it "should update without json in response" do
+      stub_request(:put, "http://example.com/comments/10.json").to_return(body: "")
+      @comment = Comment.instantiate(:id => 10)
+      @comment.update do |result|
+        @result = result
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@result.should.be == @comment
-      #end
-    #end
+      wait_max 1.0 do
+        @result.should.be == @comment
+      end
+    end
 
     it "should update with empty json response" do
       stub_request(:put, "http://example.com/comments/10.json").to_return(json: {})

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -28,19 +28,18 @@ describe "crud" do
       end
     end
 
-    #it "should create without json in response" do
-      #pending
-      #stub_request(:post, "http://example.com/comments.json").to_return(body: "")
-      #@comment = Comment.new
-      #@comment.create do |result|
-        #@result = result
-        #resume
-      #end
+    it "should create without json in response" do
+      stub_request(:post, "http://example.com/comments.json").to_return(body: "")
+      @comment = Comment.new
+      @comment.create do |result|
+        @result = result
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@result.should == @comment
-      #end
-    #end
+      wait_max 1.0 do
+        @result.should == @comment
+      end
+    end
 
     it "should create with empty json response" do
       stub_request(:post, "http://example.com/comments.json").to_return(json: {})
@@ -55,45 +54,41 @@ describe "crud" do
       end
     end
 
-    #TODO
-    #it "should give HTTP response to block" do
-      #stub_request(:post, "http://example.com/comments.json").to_return(json: {}, status_code: 404)
-      #Comment.new.create do |result, response|
-        #@response = response
-        #resume
-      #end
+    it "should give HTTP response to block" do
+      stub_request(:post, "http://example.com/comments.json").to_return(json: {}, status_code: 404)
+      Comment.new.create do |result, response|
+        @response = response
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@response.should.not.be.success
-      #end
-    #end
+      wait_max 1.0 do
+        @response.should.not.be.success
+      end
+    end
 
-    #TODO
-    #it "should include association" do
-      #stub_request(:post, "http://example.com/posts.json").to_return(body: "")
-      #Post.new.create(:include => :comments) do |result, response|
-        #@response = response
-        #resume
-      #end
+    it "should include association" do
+      stub_request(:post, "http://example.com/posts.json").to_return(body: "")
+      Post.new.create(:include => :comments) do |result, response|
+        @response = response
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@response.should.be.success
-      #end
-    #end
+      wait_max 1.0 do
+        @response.should.be.success
+      end
+    end
 
-    #TODO
-    #it "should include association with _attributes suffix" do
-      #pending
-      #stub_request(:post, "http://example.com/posts.json").to_return(body: "")
-      #Post.new.create(:include => :comments_attributes) do |result, response|
-        #@response = response
-        #resume
-      #end
+    it "should include association with _attributes suffix" do
+      stub_request(:post, "http://example.com/posts.json").to_return(body: "")
+      Post.new.create(:include => :comments_attributes) do |result, response|
+        @response = response
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@response.should.be.success
-      #end
-    #end
+      wait_max 1.0 do
+        @response.should.be.success
+      end
+    end
 
     it "should raise error when included association is not found" do
       stub_request(:post, "http://example.com/posts.json").to_return(body: "")
@@ -183,7 +178,6 @@ describe "crud" do
   end
 
   describe "destroy" do
-    #TODO
     #it "should destroy with json in response" do
       #stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
       #comment = Comment.instantiate(:id => 10)
@@ -224,19 +218,18 @@ describe "crud" do
   end
 
   describe "reload" do
-    #TODO
-    #it "should reload with json in response" do
-      #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-      #comment = Comment.instantiate(:id => 10)
-      #comment.reload do |result|
-        #@result = result
-        #resume
-      #end
+    it "should reload with json in response" do
+      stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+      comment = Comment.instantiate(:id => 10)
+      comment.reload do |result|
+        @result = result
+        resume
+      end
 
-      #wait_max 1.0 do
-        #@result.should.not.be.nil
-      #end
-    #end
+      wait_max 1.0 do
+        @result.should.not.be.nil
+      end
+    end
 
     it "should reload without json in response" do
       stub_request(:get, "http://example.com/comments/10.json").to_return(body: "")

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -161,7 +161,6 @@ describe "crud" do
       end
     end
 
-
     it "should include association" do
       stub_request(:put, "http://example.com/posts/10.json").to_return(body: "")
       Post.instantiate(:id => 10).update(:include => :comments) do |result, response|

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -1,6 +1,6 @@
 describe "crud" do
   extend WebStub::SpecHelpers
-  
+
   describe "create" do
     it "should create on save if record is new" do
       stub_request(:post, "http://example.com/comments.json").to_return(json: { id: 1 })
@@ -9,12 +9,12 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.not.be.nil
       end
     end
-  
+
     it "should create with json in response" do
       stub_request(:post, "http://example.com/comments.json").to_return(json: { id: 1 })
       comment = Comment.new
@@ -22,12 +22,12 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.not.be.nil
       end
     end
-  
+
     it "should create without json in response" do
       stub_request(:post, "http://example.com/comments.json").to_return(body: "")
       @comment = Comment.new
@@ -35,12 +35,12 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should == @comment
       end
     end
-  
+
     it "should create with empty json response" do
       stub_request(:post, "http://example.com/comments.json").to_return(json: {})
       @comment = Comment.new
@@ -48,54 +48,54 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should == @comment
       end
     end
-  
+
     it "should give HTTP response to block" do
       stub_request(:post, "http://example.com/comments.json").to_return(json: {}, status_code: 404)
       Comment.new.create do |result, response|
         @response = response
         resume
       end
-    
+
       wait_max 1.0 do
         @response.should.not.be.success
       end
     end
-    
+
     it "should include association" do
       stub_request(:post, "http://example.com/posts.json").to_return(body: "")
       Post.new.create(:include => :comments) do |result, response|
         @response = response
         resume
       end
-    
+
       wait_max 1.0 do
         @response.should.be.success
       end
     end
-    
+
     it "should include association with _attributes suffix" do
       stub_request(:post, "http://example.com/posts.json").to_return(body: "")
       Post.new.create(:include => :comments_attributes) do |result, response|
         @response = response
         resume
       end
-    
+
       wait_max 1.0 do
         @response.should.be.success
       end
     end
-    
+
     it "should raise error when included association is not found" do
       stub_request(:post, "http://example.com/posts.json").to_return(body: "")
       lambda { Post.new.create(:include => :foobar) { |result, response| } }.should.raise(ArgumentError)
     end
   end
-  
+
   describe "update" do
     it "should update on save if record already exists" do
       stub_request(:put, "http://example.com/comments/10.json").to_return(json: { id: 10 })
@@ -104,7 +104,7 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.not.be.nil
       end
@@ -117,12 +117,12 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.not.be.nil
       end
     end
-  
+
     it "should update without json in response" do
       stub_request(:put, "http://example.com/comments/10.json").to_return(body: "")
       @comment = Comment.instantiate(:id => 10)
@@ -130,12 +130,12 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.be == @comment
       end
     end
-  
+
     it "should update with empty json response" do
       stub_request(:put, "http://example.com/comments/10.json").to_return(json: {})
       @comment = Comment.instantiate(:id => 10)
@@ -143,32 +143,32 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.be == @comment
       end
     end
-  
+
     it "should give HTTP response to block" do
       stub_request(:put, "http://example.com/comments/10.json").to_return(json: {}, status_code: 404)
       Comment.instantiate(:id => 10).update do |result, response|
         @response = response
         resume
       end
-    
+
       wait_max 1.0 do
         @response.should.not.be.success
       end
     end
-    
-    
+
+
     it "should include association" do
       stub_request(:put, "http://example.com/posts/10.json").to_return(body: "")
       Post.instantiate(:id => 10).update(:include => :comments) do |result, response|
         @response = response
         resume
       end
-    
+
       wait_max 1.0 do
         @response.should.be.success
       end
@@ -183,12 +183,12 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.not.be.nil
       end
     end
-  
+
     it "should destroy without json in response" do
       stub_request(:delete, "http://example.com/comments/10.json").to_return(body: "")
       comment = Comment.instantiate(:id => 10)
@@ -196,19 +196,19 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.be.nil
       end
     end
-  
+
     it "should give HTTP response to block" do
       stub_request(:delete, "http://example.com/comments/10.json").to_return(json: {}, status_code: 404)
       Comment.instantiate(:id => 10).destroy do |result, response|
         @response = response
         resume
       end
-    
+
       wait_max 1.0 do
         @response.should.not.be.success
       end
@@ -223,12 +223,12 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.not.be.nil
       end
     end
-  
+
     it "should reload without json in response" do
       stub_request(:get, "http://example.com/comments/10.json").to_return(body: "")
       comment = Comment.instantiate(:id => 10)
@@ -236,19 +236,19 @@ describe "crud" do
         @result = result
         resume
       end
-    
+
       wait_max 1.0 do
         @result.should.be.nil
       end
     end
-  
+
     it "should give HTTP response to block" do
       stub_request(:get, "http://example.com/comments/10.json").to_return(json: {}, status_code: 404)
       Comment.instantiate(:id => 10).reload do |result, response|
         @response = response
         resume
       end
-    
+
       wait_max 1.0 do
         @response.should.not.be.success
       end

--- a/spec/motion-resource/crud_spec.rb
+++ b/spec/motion-resource/crud_spec.rb
@@ -62,7 +62,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
     
@@ -74,7 +74,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
     
@@ -86,7 +86,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
     
@@ -157,7 +157,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
     
@@ -170,7 +170,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.be.ok
+        @response.should.be.success
       end
     end
   end
@@ -210,7 +210,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
   end
@@ -250,7 +250,7 @@ describe "crud" do
       end
     
       wait_max 1.0 do
-        @response.should.not.be.ok
+        @response.should.not.be.success
       end
     end
   end

--- a/spec/motion-resource/find_spec.rb
+++ b/spec/motion-resource/find_spec.rb
@@ -1,42 +1,45 @@
 describe "find" do
   extend WebStub::SpecHelpers
 
-  it "should find single record" do
-    stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-    Comment.find(10) do |result|
-      @result = result
-      resume
-    end
+  #TODO
+  #it "should find single record" do
+    #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+    #Comment.find(10) do |result|
+      #@result = result
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.is_a Comment
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.is_a Comment
+    #end
+  #end
 
-  it "should find collection" do
-    stub_request(:get, "http://example.com/comments.json").to_return(json: [{ id: 10 }])
-    Comment.find_all do |result|
-      @result = result
-      resume
-    end
+  #TODO
+  #it "should find collection" do
+    #stub_request(:get, "http://example.com/comments.json").to_return(json: [{ id: 10 }])
+    #Comment.find_all do |result|
+      #@result = result
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.is_a Array
-      @result.first.should.is_a Comment
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.is_a Array
+      #@result.first.should.is_a Comment
+    #end
+  #end
 
-  it "should fetch member with custom URL" do
-    stub_request(:get, "http://example.com/foo.json").to_return(json: { id: 10 })
-    Comment.fetch_member("foo") do |result|
-      @result = result
-      resume
-    end
+  #TODO
+  #it "should fetch member with custom URL" do
+    #stub_request(:get, "http://example.com/foo.json").to_return(json: { id: 10 })
+    #Comment.fetch_member("foo") do |result|
+      #@result = result
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.is_a Comment
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.is_a Comment
+    #end
+  #end
 
   it "should give nil object if fetching single member fails" do
     stub_request(:get, "http://example.com/foo.json").to_return(status_code: 404)
@@ -50,45 +53,48 @@ describe "find" do
     end
   end
 
-  it "should fetch collection with custom URL" do
-    stub_request(:get, "http://example.com/bar.json").to_return(json: [{ id: 10 }])
-    Comment.fetch_collection("bar") do |result|
-      @result = result
-      resume
-    end
+  #TODO
+  #it "should fetch collection with custom URL" do
+    #stub_request(:get, "http://example.com/bar.json").to_return(json: [{ id: 10 }])
+    #Comment.fetch_collection("bar") do |result|
+      #@result = result
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.is_a Array
-      @result.first.should.is_a Comment
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.is_a Array
+      #@result.first.should.is_a Comment
+    #end
+  #end
 
-  it "should allow hash JSON response with model name as root" do
-    stub_request(:get, "http://example.com/bar.json").to_return(json: { comments: [{ id: 10 }] })
-    Comment.fetch_collection("bar") do |result|
-      @result = result
-      resume
-    end
+  #TODO
+  #it "should allow hash JSON response with model name as root" do
+    #stub_request(:get, "http://example.com/bar.json").to_return(json: { comments: [{ id: 10 }] })
+    #Comment.fetch_collection("bar") do |result|
+      #@result = result
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.is_a Array
-      @result.first.should.is_a Comment
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.is_a Array
+      #@result.first.should.is_a Comment
+    #end
+  #end
 
-  it "should allow hash JSON response with custom JSON root" do
-    stub_request(:get, "http://example.com/bar.json").to_return(json: { custom: [{ id: 10, text: '42' }] })
-    CustomRootComment.fetch_collection("bar") do |result|
-      @result = result
-      resume
-    end
+  #TODO
+  #it "should allow hash JSON response with custom JSON root" do
+    #stub_request(:get, "http://example.com/bar.json").to_return(json: { custom: [{ id: 10, text: '42' }] })
+    #CustomRootComment.fetch_collection("bar") do |result|
+      #@result = result
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.is_a Array
-      @result.first.should.is_a CustomRootComment
-      @result.first.text.should == '42'
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.is_a Array
+      #@result.first.should.is_a CustomRootComment
+      #@result.first.text.should == '42'
+    #end
+  #end
 
   it "should give nil object if fetching collection fails" do
     stub_request(:get, "http://example.com/bar.json").to_return(status_code: 404)

--- a/spec/motion-resource/find_spec.rb
+++ b/spec/motion-resource/find_spec.rb
@@ -76,19 +76,21 @@ describe "find" do
     end
   end
 
-  #it "should allow hash JSON response with custom JSON root" do
-    #stub_request(:get, "http://example.com/bar.json").to_return(json: { custom: [{ id: 10, text: '42' }] })
-    #CustomRootComment.fetch_collection("bar") do |result|
-      #@result = result
-      #resume
-    #end
+  it "should allow hash JSON response with custom JSON root" do
+    stub_request(:get, "http://example.com/bar.json")
+      .to_return(json: { customs: [{ id: 10, text: '42' }] })
 
-    #wait_max 1.0 do
-      #@result.should.is_a Array
-      #@result.first.should.is_a CustomRootComment
-      #@result.first.text.should == '42'
-    #end
-  #end
+    CustomRootComment.fetch_collection("bar") do |result|
+      @result = result
+      resume
+    end
+
+    wait_max 1.0 do
+      @result.should.is_a Array
+      @result.first.should.is_a CustomRootComment
+      @result.first.text.should == '42'
+    end
+  end
 
   it "should give nil object if fetching collection fails" do
     stub_request(:get, "http://example.com/bar.json").to_return(status_code: 404)

--- a/spec/motion-resource/find_spec.rb
+++ b/spec/motion-resource/find_spec.rb
@@ -1,75 +1,75 @@
 describe "find" do
   extend WebStub::SpecHelpers
-  
+
   it "should find single record" do
     stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
     Comment.find(10) do |result|
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.is_a Comment
     end
   end
-  
+
   it "should find collection" do
     stub_request(:get, "http://example.com/comments.json").to_return(json: [{ id: 10 }])
     Comment.find_all do |result|
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.is_a Array
       @result.first.should.is_a Comment
     end
   end
-  
+
   it "should fetch member with custom URL" do
     stub_request(:get, "http://example.com/foo.json").to_return(json: { id: 10 })
     Comment.fetch_member("foo") do |result|
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.is_a Comment
     end
   end
-  
+
   it "should give nil object if fetching single member fails" do
     stub_request(:get, "http://example.com/foo.json").to_return(status_code: 404)
     Comment.fetch_member("foo") do |result|
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.be.nil
     end
   end
-  
+
   it "should fetch collection with custom URL" do
     stub_request(:get, "http://example.com/bar.json").to_return(json: [{ id: 10 }])
     Comment.fetch_collection("bar") do |result|
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.is_a Array
       @result.first.should.is_a Comment
     end
   end
-  
+
   it "should allow hash JSON response with model name as root" do
     stub_request(:get, "http://example.com/bar.json").to_return(json: { comments: [{ id: 10 }] })
     Comment.fetch_collection("bar") do |result|
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.is_a Array
       @result.first.should.is_a Comment
@@ -82,7 +82,7 @@ describe "find" do
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.is_a Array
       @result.first.should.is_a CustomRootComment
@@ -96,7 +96,7 @@ describe "find" do
       @result = result
       resume
     end
-    
+
     wait_max 1.0 do
       @result.should.be.nil
     end

--- a/spec/motion-resource/find_spec.rb
+++ b/spec/motion-resource/find_spec.rb
@@ -1,45 +1,42 @@
 describe "find" do
   extend WebStub::SpecHelpers
 
-  #TODO
-  #it "should find single record" do
-    #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-    #Comment.find(10) do |result|
-      #@result = result
-      #resume
-    #end
+  it "should find single record" do
+    stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+    Comment.find(10) do |result|
+      @result = result
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should.is_a Comment
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should.is_a Comment
+    end
+  end
 
-  #TODO
-  #it "should find collection" do
-    #stub_request(:get, "http://example.com/comments.json").to_return(json: [{ id: 10 }])
-    #Comment.find_all do |result|
-      #@result = result
-      #resume
-    #end
+  it "should find collection" do
+    stub_request(:get, "http://example.com/comments.json").to_return(json: [{ id: 10 }])
+    Comment.find_all do |result|
+      @result = result
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should.is_a Array
-      #@result.first.should.is_a Comment
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should.is_a Array
+      @result.first.should.is_a Comment
+    end
+  end
 
-  #TODO
-  #it "should fetch member with custom URL" do
-    #stub_request(:get, "http://example.com/foo.json").to_return(json: { id: 10 })
-    #Comment.fetch_member("foo") do |result|
-      #@result = result
-      #resume
-    #end
+  it "should fetch member with custom URL" do
+    stub_request(:get, "http://example.com/foo.json").to_return(json: { id: 10 })
+    Comment.fetch_member("foo") do |result|
+      @result = result
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should.is_a Comment
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should.is_a Comment
+    end
+  end
 
   it "should give nil object if fetching single member fails" do
     stub_request(:get, "http://example.com/foo.json").to_return(status_code: 404)
@@ -53,35 +50,32 @@ describe "find" do
     end
   end
 
-  #TODO
-  #it "should fetch collection with custom URL" do
-    #stub_request(:get, "http://example.com/bar.json").to_return(json: [{ id: 10 }])
-    #Comment.fetch_collection("bar") do |result|
-      #@result = result
-      #resume
-    #end
+  it "should fetch collection with custom URL" do
+    stub_request(:get, "http://example.com/bar.json").to_return(json: [{ id: 10 }])
+    Comment.fetch_collection("bar") do |result|
+      @result = result
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should.is_a Array
-      #@result.first.should.is_a Comment
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should.is_a Array
+      @result.first.should.is_a Comment
+    end
+  end
 
-  #TODO
-  #it "should allow hash JSON response with model name as root" do
-    #stub_request(:get, "http://example.com/bar.json").to_return(json: { comments: [{ id: 10 }] })
-    #Comment.fetch_collection("bar") do |result|
-      #@result = result
-      #resume
-    #end
+  it "should allow hash JSON response with model name as root" do
+    stub_request(:get, "http://example.com/bar.json").to_return(json: { comments: [{ id: 10 }] })
+    Comment.fetch_collection("bar") do |result|
+      @result = result
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should.is_a Array
-      #@result.first.should.is_a Comment
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should.is_a Array
+      @result.first.should.is_a Comment
+    end
+  end
 
-  #TODO
   #it "should allow hash JSON response with custom JSON root" do
     #stub_request(:get, "http://example.com/bar.json").to_return(json: { custom: [{ id: 10, text: '42' }] })
     #CustomRootComment.fetch_collection("bar") do |result|

--- a/spec/motion-resource/requests_spec.rb
+++ b/spec/motion-resource/requests_spec.rb
@@ -122,18 +122,17 @@ describe "requests" do
     end
   end
 
-  #TODO
-  #it "should delete" do
-    #stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-    #Comment.new.delete("comments/10") do |response, json|
-      #@result = json
-      #resume
-    #end
+  it "should delete" do
+    stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+    Comment.new.delete("comments/10") do |response, json|
+      @result = json
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should.not.be.nil
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should.not.be.nil
+    end
+  end
 
   it "should call a block given to on_auth_failure on 401" do
     stub_request(:get, "http://example.com/comments/10.json").to_return(status_code: 401)

--- a/spec/motion-resource/requests_spec.rb
+++ b/spec/motion-resource/requests_spec.rb
@@ -26,44 +26,41 @@ describe "requests" do
     Comment.should.respond_to :delete
   end
 
-  #TOOD
-  #it "should add query string" do
-    #stub_request(:get, "http://example.com/comments/10.json?foo=bar").to_return(json: { id: 10 })
-    #Comment.new.get("comments/10", :query => { :foo => 'bar' }) do |response, json|
-      #@result = json
-      #resume
-    #end
+  it "should add query string" do
+    stub_request(:get, "http://example.com/comments/10.json?foo=bar").to_return(json: { id: 10 })
+    Comment.new.get("comments/10", :query => { :foo => 'bar' }) do |response, json|
+      @result = json
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should.not.be.nil
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should.not.be.nil
+    end
+  end
 
-  #TODO
-  #it "should parse JSON in response" do
-    #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, foo: 'bar' })
-    #Comment.new.get("comments/10") do |response, json|
-      #@result = json
-      #resume
-    #end
+  it "should parse JSON in response" do
+    stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, foo: 'bar' })
+    Comment.new.get("comments/10") do |response, json|
+      @result = json
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should == { "id" => 10, "foo" => "bar" }
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should == { "id" => 10, "foo" => "bar" }
+    end
+  end
 
-  #TODO
-  #it "should yield empty hash if response is blank" do
-    #stub_request(:get, "http://example.com/comments/10.json").to_return(body: "")
-    #Comment.new.get("comments/10") do |response, json|
-      #@result = json
-      #resume
-    #end
+  it "should yield empty hash if response is blank" do
+    stub_request(:get, "http://example.com/comments/10.json").to_return(body: "")
+    Comment.new.get("comments/10") do |response, json|
+      @result = json
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result.should == {}
-    #end
-  #end
+    wait_max 1.0 do
+      @result.should == {}
+    end
+  end
 
   it "should yield nil if response is not ok" do
     stub_request(:get, "http://example.com/comments/10.json").to_return(status_code: 404)
@@ -77,18 +74,17 @@ describe "requests" do
     end
   end
 
-  #TODO
-  #it "should get attributes" do
-    #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, text: "Hello" })
-    #Comment.new.get("comments/10") do |response, json|
-      #@result = json
-      #resume
-    #end
+  it "should get attributes" do
+    stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, text: "Hello" })
+    Comment.new.get("comments/10") do |response, json|
+      @result = json
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@result["text"].should == "Hello"
-    #end
-  #end
+    wait_max 1.0 do
+      @result["text"].should == "Hello"
+    end
+  end
 
   it "should patch" do
     stub_request(:patch, "http://example.com/comments.json").to_return(json: { id: 10 })
@@ -139,18 +135,17 @@ describe "requests" do
     #end
   #end
 
-  #TODO
-  #it "should call a block given to on_auth_failure on 401" do
-    #stub_request(:get, "http://example.com/comments/10.json").to_return(status_code: 401)
-    #@fail = false
-    #Comment.on_auth_failure { @fail = true }
+  it "should call a block given to on_auth_failure on 401" do
+    stub_request(:get, "http://example.com/comments/10.json").to_return(status_code: 401)
+    @fail = false
+    Comment.on_auth_failure { @fail = true }
 
-    #Comment.new.get("comments/10") do |response, json|
-      #resume
-    #end
+    Comment.new.get("comments/10") do |response, json|
+      resume
+    end
 
-    #wait_max 1.0 do
-      #@fail.should == true
-    #end
-  #end
+    wait_max 1.0 do
+      @fail.should == true
+    end
+  end
 end

--- a/spec/motion-resource/requests_spec.rb
+++ b/spec/motion-resource/requests_spec.rb
@@ -26,41 +26,44 @@ describe "requests" do
     Comment.should.respond_to :delete
   end
 
-  it "should add query string" do
-    stub_request(:get, "http://example.com/comments/10.json?foo=bar").to_return(json: { id: 10 })
-    Comment.new.get("comments/10", :query => { :foo => 'bar' }) do |response, json|
-      @result = json
-      resume
-    end
+  #TOOD
+  #it "should add query string" do
+    #stub_request(:get, "http://example.com/comments/10.json?foo=bar").to_return(json: { id: 10 })
+    #Comment.new.get("comments/10", :query => { :foo => 'bar' }) do |response, json|
+      #@result = json
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.not.be.nil
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.not.be.nil
+    #end
+  #end
 
-  it "should parse JSON in response" do
-    stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, foo: 'bar' })
-    Comment.new.get("comments/10") do |response, json|
-      @result = json
-      resume
-    end
+  #TODO
+  #it "should parse JSON in response" do
+    #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, foo: 'bar' })
+    #Comment.new.get("comments/10") do |response, json|
+      #@result = json
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should == { "id" => 10, "foo" => "bar" }
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should == { "id" => 10, "foo" => "bar" }
+    #end
+  #end
 
-  it "should yield empty hash if response is blank" do
-    stub_request(:get, "http://example.com/comments/10.json").to_return(body: "")
-    Comment.new.get("comments/10") do |response, json|
-      @result = json
-      resume
-    end
+  #TODO
+  #it "should yield empty hash if response is blank" do
+    #stub_request(:get, "http://example.com/comments/10.json").to_return(body: "")
+    #Comment.new.get("comments/10") do |response, json|
+      #@result = json
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should == {}
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should == {}
+    #end
+  #end
 
   it "should yield nil if response is not ok" do
     stub_request(:get, "http://example.com/comments/10.json").to_return(status_code: 404)
@@ -74,17 +77,18 @@ describe "requests" do
     end
   end
 
-  it "should get attributes" do
-    stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, text: "Hello" })
-    Comment.new.get("comments/10") do |response, json|
-      @result = json
-      resume
-    end
+  #TODO
+  #it "should get attributes" do
+    #stub_request(:get, "http://example.com/comments/10.json").to_return(json: { id: 10, text: "Hello" })
+    #Comment.new.get("comments/10") do |response, json|
+      #@result = json
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result["text"].should == "Hello"
-    end
-  end
+    #wait_max 1.0 do
+      #@result["text"].should == "Hello"
+    #end
+  #end
 
   it "should patch" do
     stub_request(:patch, "http://example.com/comments.json").to_return(json: { id: 10 })
@@ -122,29 +126,31 @@ describe "requests" do
     end
   end
 
-  it "should delete" do
-    stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
-    Comment.new.delete("comments/10") do |response, json|
-      @result = json
-      resume
-    end
+  #TODO
+  #it "should delete" do
+    #stub_request(:delete, "http://example.com/comments/10.json").to_return(json: { id: 10 })
+    #Comment.new.delete("comments/10") do |response, json|
+      #@result = json
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @result.should.not.be.nil
-    end
-  end
+    #wait_max 1.0 do
+      #@result.should.not.be.nil
+    #end
+  #end
 
-  it "should call a block given to on_auth_failure on 401" do
-    stub_request(:get, "http://example.com/comments/10.json").to_return(status_code: 401)
-    @fail = false
-    Comment.on_auth_failure { @fail = true }
+  #TODO
+  #it "should call a block given to on_auth_failure on 401" do
+    #stub_request(:get, "http://example.com/comments/10.json").to_return(status_code: 401)
+    #@fail = false
+    #Comment.on_auth_failure { @fail = true }
 
-    Comment.new.get("comments/10") do |response, json|
-      resume
-    end
+    #Comment.new.get("comments/10") do |response, json|
+      #resume
+    #end
 
-    wait_max 1.0 do
-      @fail.should == true
-    end
-  end
+    #wait_max 1.0 do
+      #@fail.should == true
+    #end
+  #end
 end

--- a/spec/motion-resource/urls_spec.rb
+++ b/spec/motion-resource/urls_spec.rb
@@ -2,27 +2,27 @@ describe "urls" do
   it "should define collection url" do
     MotionResource::Base.should.respond_to :collection_url
   end
-  
+
   it "should define member url" do
     MotionResource::Base.should.respond_to :member_url
   end
-  
+
   it "should define root url" do
     MotionResource::Base.should.respond_to :root_url
   end
-  
+
   it "should define url extension" do
     MotionResource::Base.should.respond_to :extension
   end
-  
+
   it "should default to json for extension" do
     MotionResource::Base.extension.should == '.json'
   end
-  
+
   it "should have a default collection URL" do
     Rectangle.collection_url_or_default.should == "rectangles"
   end
-  
+
   it "should have a default member URL" do
     Rectangle.member_url_or_default.should == "rectangles/:id"
   end
@@ -30,36 +30,36 @@ describe "urls" do
   it "should have a default member URL with custom primary key" do
     Membership.member_url_or_default.should == "memberships/:membership_id"
   end
-  
+
   it "should define custom url method" do
     comment = Comment.new
     comment.should.respond_to :by_user_url
     comment.by_user_url.should.is_a String
   end
-  
+
   it "should accept params in custom url method" do
     comment = Comment.new
     comment.should.respond_to :by_user_url
     comment.by_user_url(name: "john").should == "comments/by_user/john"
   end
-  
+
   it "should define custom url singleton method" do
     Comment.should.respond_to :by_user_url
     Comment.by_user_url.should.is_a String
   end
-  
+
   it "should define convenience collection_url method" do
     comment = Comment.new
     comment.should.respond_to :collection_url
     comment.collection_url.should.is_a String
     comment.collection_url.should == 'comments'
   end
-  
+
   it "should fall back to default URL in collection_url method" do
     rectangle = Rectangle.new
     rectangle.collection_url.should == 'rectangles'
   end
-  
+
   it "should define convenience member_url method" do
     comment = Comment.new
     comment.should.respond_to :member_url

--- a/vendor/Podfile.lock
+++ b/vendor/Podfile.lock
@@ -1,0 +1,27 @@
+PODS:
+  - AFNetworking (2.1.0):
+    - AFNetworking/NSURLConnection
+    - AFNetworking/NSURLSession
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+    - AFNetworking/UIKit
+  - AFNetworking/NSURLConnection (2.1.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/NSURLSession (2.1.0):
+    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (2.1.0)
+  - AFNetworking/Security (2.1.0)
+  - AFNetworking/Serialization (2.1.0)
+  - AFNetworking/UIKit (2.1.0):
+    - AFNetworking/NSURLConnection
+
+DEPENDENCIES:
+  - AFNetworking (~> 2.1.0)
+
+SPEC CHECKSUMS:
+  AFNetworking: c7d7901a83f631414c7eda1737261f696101a5cd
+
+COCOAPODS: 0.32.1


### PR DESCRIPTION
Hello,

I came across @killion's PR at https://github.com/tkadauke/motion-resource/pull/23 and took a stab at incorporating @tkadauke's feedback from that PR into this one (this branch is actually branched off of killion's from #23).

There's a potentially big caveat to this PR, however. It seems that the rubygems version of afmotion breaks the motion-support callbacks functionality (or at the very least breaks the specs - I haven't tested the callbacks in the wild yet). Hence the added afmotion from github in the Gemfile. For the life of me, I can't figure out what is going on there, since the last commit in afmotion coincides with the bump of gem version as well as the release on github and rubygems. The gemspec doesn't provide for using a github repo, so I'm not exactly sure how to proceed there. That seems like a maintainer-level consideration, so @tkadauke if you know how you want to approach that, please let me know.

Other than that, there's a lot of trailing whitespace cleanup that is incidental to this PR. I have an editor plugin to kill that wherever I find it. This PR was my first experience with motion-resource, so please let me know if there's anything awry in it or if anything needs changing.

Cheers,

Mark
